### PR TITLE
Add property and investor endpoints

### DIFF
--- a/app/Http/Controllers/InvestorController.php
+++ b/app/Http/Controllers/InvestorController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Investor;
+use Illuminate\Http\Request;
+
+class InvestorController extends Controller
+{
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:investors,email',
+            'phone' => 'nullable|string|max:30',
+        ]);
+
+        $investor = Investor::create($data);
+
+        return response()->json($investor, 201);
+    }
+}

--- a/app/Http/Controllers/PropertyController.php
+++ b/app/Http/Controllers/PropertyController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Property;
+use Illuminate\Http\Request;
+
+class PropertyController extends Controller
+{
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'location' => 'required|string|max:255',
+            'price' => 'required|numeric',
+        ]);
+
+        $property = Property::create($data);
+
+        return response()->json($property, 201);
+    }
+}

--- a/app/Models/Investor.php
+++ b/app/Models/Investor.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Investor extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'email',
+        'phone',
+    ];
+}

--- a/app/Models/Property.php
+++ b/app/Models/Property.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Property extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'title',
+        'description',
+        'location',
+        'price',
+    ];
+}

--- a/database/migrations/2025_06_17_180001_create_properties_table.php
+++ b/database/migrations/2025_06_17_180001_create_properties_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('properties', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->string('location');
+            $table->decimal('price', 15, 2);
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('properties');
+    }
+};

--- a/database/migrations/2025_06_17_180002_create_investors_table.php
+++ b/database/migrations/2025_06_17_180002_create_investors_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('investors', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('phone')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('investors');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,8 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\PropertyController;
+use App\Http\Controllers\InvestorController;
 
 /*
 |--------------------------------------------------------------------------
@@ -19,6 +21,8 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 });
 Route::post('auth/login', [AuthController::class, 'login']);
 Route::post('auth/register', [AuthController::class, 'register']);
+Route::post('properties', [PropertyController::class, 'store']);
+Route::post('investors', [InvestorController::class, 'store']);
 Route::middleware(['auth:api'])->group(function() {
     Route::get('user/profile', [UserController::class, 'profile']);
     Route::get('wallet', [WalletController::class, 'show']);

--- a/tests/Feature/InvestorRegistrationTest.php
+++ b/tests/Feature/InvestorRegistrationTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class InvestorRegistrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_investor_can_be_registered(): void
+    {
+        $response = $this->postJson('/api/investors', [
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'phone' => '123456789',
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('investors', ['email' => 'john@example.com']);
+    }
+}

--- a/tests/Feature/PropertyRegistrationTest.php
+++ b/tests/Feature/PropertyRegistrationTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PropertyRegistrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_property_can_be_registered(): void
+    {
+        $response = $this->postJson('/api/properties', [
+            'title' => 'House',
+            'description' => 'A big house',
+            'location' => 'City',
+            'price' => 1000,
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('properties', ['title' => 'House']);
+    }
+}


### PR DESCRIPTION
## Summary
- add Property and Investor models
- create controllers for registering properties and investors
- define migrations for `properties` and `investors`
- expose new API routes for property and investor registration
- add feature tests for these endpoints

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6851ad019d74832899a889199dc76b81