### PR TITLE
Require auth for property creation

### DIFF
--- a/app/Http/Controllers/PropertyController.php
+++ b/app/Http/Controllers/PropertyController.php
@@ -49,7 +49,7 @@ class PropertyController extends Controller
             'price' => 'required|numeric',
         ]);
 
-        $property = Property::create($data);
+        $property = $request->user()->properties()->create($data);
 
         return response()->json($property, 201);
     }

--- a/app/Models/Property.php
+++ b/app/Models/Property.php
@@ -9,10 +9,17 @@ class Property extends Model
 {
     use HasFactory;
 
+
     protected $fillable = [
         'title',
         'description',
         'location',
         'price',
+        'user_id',
     ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -47,5 +47,9 @@ class User extends Authenticatable implements JWTSubject
     public function investments() {
         return $this->hasMany(Investment::class);
     }
+
+    public function properties() {
+        return $this->hasMany(Property::class);
+    }
 }
 

--- a/database/migrations/2025_06_30_000000_add_user_id_to_properties_table.php
+++ b/database/migrations/2025_06_30_000000_add_user_id_to_properties_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('properties', function (Blueprint $table) {
+            $table->foreignId('user_id')->after('id')->constrained()->cascadeOnDelete();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('properties', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('user_id');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,7 +22,6 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 });
 Route::post('auth/login', [AuthController::class, 'login']);
 Route::post('auth/register', [AuthController::class, 'register']);
-Route::post('properties', [PropertyController::class, 'store']);
 Route::post('investors', [InvestorController::class, 'store']);
 Route::middleware(['auth:api'])->group(function() {
     Route::get('user/profile', [UserController::class, 'profile']);

--- a/tests/Feature/PropertyRegistrationTest.php
+++ b/tests/Feature/PropertyRegistrationTest.php
@@ -11,7 +11,9 @@ class PropertyRegistrationTest extends TestCase
 
     public function test_property_can_be_registered(): void
     {
-        $response = $this->postJson('/api/properties', [
+        $user = \App\Models\User::factory()->create();
+
+        $response = $this->actingAs($user, 'api')->postJson('/api/properties', [
             'title' => 'House',
             'description' => 'A big house',
             'location' => 'City',
@@ -19,6 +21,9 @@ class PropertyRegistrationTest extends TestCase
         ]);
 
         $response->assertStatus(201);
-        $this->assertDatabaseHas('properties', ['title' => 'House']);
+        $this->assertDatabaseHas('properties', [
+            'title' => 'House',
+            'user_id' => $user->id,
+        ]);
     }
 }


### PR DESCRIPTION
## Summary
- ensure property creation requires authentication and store creator
- add migration with `user_id` in properties
- reference user relationship in models and controller
- fix tests

## Testing
- `phpunit` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6851d782e584832897615bc79abd32cd