### PR TITLE
Adiciona campos a investidores

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -37,7 +37,7 @@ public function login(Request $request)
         $user = User::create([
             'nome' => $data['nome'],
             'email' => $data['email'],
-            'senha_hash' => hash('sha256', $data['password']),
+            'password' => hash('sha256', $data['password']),
             'tipo' => $data['tipo'] ?? 'investidor',
             'telefone' => $data['telefone'] ?? null,
         ]);

--- a/app/Http/Controllers/InvestorController.php
+++ b/app/Http/Controllers/InvestorController.php
@@ -10,9 +10,12 @@ class InvestorController extends Controller
     public function store(Request $request)
     {
         $data = $request->validate([
-            'name' => 'required|string|max:255',
+            'nome' => 'required|string|max:255',
             'email' => 'required|email|unique:investors,email',
-            'phone' => 'nullable|string|max:30',
+            'documento' => 'required|string|max:50',
+            'telefone' => 'nullable|string|max:30',
+            'status_kyc' => 'in:pendente,aprovado,rejeitado',
+            'carteira_blockchain' => 'nullable|string|max:255',
         ]);
 
         $investor = Investor::create($data);

--- a/app/Models/Investor.php
+++ b/app/Models/Investor.php
@@ -10,8 +10,11 @@ class Investor extends Model
     use HasFactory;
 
     protected $fillable = [
-        'name',
+        'nome',
         'email',
-        'phone',
+        'documento',
+        'telefone',
+        'status_kyc',
+        'carteira_blockchain',
     ];
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -19,7 +19,7 @@ class User extends Authenticatable implements JWTSubject
     protected $fillable = [
         'nome',
         'email',
-        'senha_hash',
+        'password',
         'tipo',
         'telefone',
         'status',

--- a/database/migrations/2025_06_17_180002_create_investors_table.php
+++ b/database/migrations/2025_06_17_180002_create_investors_table.php
@@ -10,9 +10,12 @@ return new class extends Migration
     {
         Schema::create('investors', function (Blueprint $table) {
             $table->id();
-            $table->string('name');
+            $table->string('nome');
             $table->string('email')->unique();
-            $table->string('phone')->nullable();
+            $table->string('documento');
+            $table->string('telefone')->nullable();
+            $table->enum('status_kyc', ['pendente', 'aprovado', 'rejeitado'])->default('pendente');
+            $table->string('carteira_blockchain')->nullable();
             $table->timestamps();
         });
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,10 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\PropertyController;
 use App\Http\Controllers\InvestorController;
+use App\Http\Controllers\UserController;
+use App\Http\Controllers\WalletController;
+use App\Http\Controllers\InvestmentController;
+use App\Http\Controllers\SupportTicketController;
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Feature/ApiRoutesTest.php
+++ b/tests/Feature/ApiRoutesTest.php
@@ -55,10 +55,13 @@ class ApiRoutesTest extends TestCase
         $this->withoutMiddleware();
         $property = Property::create([
             'titulo' => 'Test',
+            'descricao' => 'Desc',
             'localizacao' => 'Loc',
             'valor_total' => 1,
             'qtd_tokens' => 1,
             'status' => 'ativo',
+            'data_tokenizacao' => now(),
+            'user_id' => 1,
         ]);
 
         $this->getJson('/api/properties')->assertStatus(200);
@@ -73,10 +76,13 @@ class ApiRoutesTest extends TestCase
         $this->withoutMiddleware();
         $property = Property::create([
             'titulo' => 'Tokens',
+            'descricao' => 'Desc',
             'localizacao' => 'Loc',
             'valor_total' => 2,
             'qtd_tokens' => 1,
             'status' => 'ativo',
+            'data_tokenizacao' => now(),
+            'user_id' => 1,
         ]);
         $this->getJson('/api/properties/' . $property->id . '/tokens')
             ->assertStatus(200);

--- a/tests/Feature/InvestorRegistrationTest.php
+++ b/tests/Feature/InvestorRegistrationTest.php
@@ -12,9 +12,10 @@ class InvestorRegistrationTest extends TestCase
     public function test_investor_can_be_registered(): void
     {
         $response = $this->postJson('/api/investors', [
-            'name' => 'John Doe',
+            'nome' => 'John Doe',
             'email' => 'john@example.com',
-            'phone' => '123456789',
+            'documento' => '12345678901',
+            'telefone' => '123456789',
         ]);
 
         $response->assertStatus(201);

--- a/tests/Feature/PropertyRegistrationTest.php
+++ b/tests/Feature/PropertyRegistrationTest.php
@@ -20,6 +20,7 @@ class PropertyRegistrationTest extends TestCase
             'valor_total' => 1000,
             'qtd_tokens' => 1,
             'status' => 'ativo',
+            'data_tokenizacao' => now(),
         ]);
 
         $response->assertStatus(201);


### PR DESCRIPTION
## Summary
- adicionar dados de KYC e carteira na tabela de investidores
- atualizar o modelo e o controller de Investor
- ajustar AuthController e User para usar campo `password`
- corrigir rotas importando todos os controllers
- ajustar testes conforme novas colunas obrigatórias

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6855f79a1df083288cd011c4cc94170f