### PR TITLE
Add transacoes_financeiras CRUD

### DIFF
--- a/app/Http/Controllers/TransacaoFinanceiraController.php
+++ b/app/Http/Controllers/TransacaoFinanceiraController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\TransacaoFinanceira;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class TransacaoFinanceiraController extends Controller
+{
+    public function index()
+    {
+        return response()->json(TransacaoFinanceira::all());
+    }
+
+    public function show($id)
+    {
+        $transacao = TransacaoFinanceira::findOrFail($id);
+        return response()->json($transacao);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'id_investidor' => 'required|integer|exists:investors,id',
+            'tipo' => 'required|in:deposito,saque,rendimento,taxa',
+            'valor' => 'required|numeric',
+            'status' => 'in:pendente,concluido,falhou',
+            'referencia' => 'nullable|string',
+            'data_transacao' => 'required|date',
+        ]);
+        $data['id'] = (string) Str::uuid();
+        $transacao = TransacaoFinanceira::create($data);
+        return response()->json($transacao, 201);
+    }
+
+    public function update(Request $request, $id)
+    {
+        $transacao = TransacaoFinanceira::findOrFail($id);
+        $data = $request->validate([
+            'id_investidor' => 'sometimes|integer|exists:investors,id',
+            'tipo' => 'sometimes|in:deposito,saque,rendimento,taxa',
+            'valor' => 'sometimes|numeric',
+            'status' => 'sometimes|in:pendente,concluido,falhou',
+            'referencia' => 'nullable|string',
+            'data_transacao' => 'sometimes|date',
+        ]);
+        $transacao->update($data);
+        return response()->json($transacao);
+    }
+
+    public function destroy($id)
+    {
+        $transacao = TransacaoFinanceira::findOrFail($id);
+        $transacao->delete();
+        return response()->json(['deleted' => true]);
+    }
+}

--- a/app/Models/TransacaoFinanceira.php
+++ b/app/Models/TransacaoFinanceira.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TransacaoFinanceira extends Model
+{
+    use HasFactory;
+
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'id',
+        'id_investidor',
+        'tipo',
+        'valor',
+        'status',
+        'referencia',
+        'data_transacao',
+    ];
+}

--- a/database/factories/TransacaoFinanceiraFactory.php
+++ b/database/factories/TransacaoFinanceiraFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\TransacaoFinanceira;
+use App\Models\Investor;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class TransacaoFinanceiraFactory extends Factory
+{
+    protected $model = TransacaoFinanceira::class;
+
+    public function definition()
+    {
+        return [
+            'id' => (string) Str::uuid(),
+            'id_investidor' => Investor::factory(),
+            'tipo' => $this->faker->randomElement(['deposito','saque','rendimento','taxa']),
+            'valor' => $this->faker->randomFloat(2, 10, 1000),
+            'status' => $this->faker->randomElement(['pendente','concluido','falhou']),
+            'referencia' => $this->faker->sentence(),
+            'data_transacao' => $this->faker->dateTime(),
+        ];
+    }
+}

--- a/database/migrations/2025_07_01_000000_create_transacoes_financeiras_table.php
+++ b/database/migrations/2025_07_01_000000_create_transacoes_financeiras_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('transacoes_financeiras', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('id_investidor')->constrained('investors');
+            $table->enum('tipo', ['deposito', 'saque', 'rendimento', 'taxa']);
+            $table->decimal('valor', 15, 2);
+            $table->enum('status', ['pendente', 'concluido', 'falhou'])->default('pendente');
+            $table->text('referencia')->nullable();
+            $table->dateTime('data_transacao');
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('transacoes_financeiras');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\UserController;
 use App\Http\Controllers\WalletController;
 use App\Http\Controllers\InvestmentController;
 use App\Http\Controllers\SupportTicketController;
+use App\Http\Controllers\TransacaoFinanceiraController;
 
 /*
 |--------------------------------------------------------------------------
@@ -41,5 +42,6 @@ Route::middleware(['auth:api'])->group(function() {
     Route::post('investments/purchase', [InvestmentController::class, 'purchase']);
     Route::get('investments/history', [InvestmentController::class, 'history']);
     Route::resource('support-tickets', SupportTicketController::class);
+    Route::resource('transacoes-financeiras', TransacaoFinanceiraController::class);
     // ...outros endpoints
 });

--- a/tests/Feature/ApiRoutesTest.php
+++ b/tests/Feature/ApiRoutesTest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use App\Models\Property;
 use App\Models\Investor;
+use App\Models\TransacaoFinanceira;
 
 class ApiRoutesTest extends TestCase
 {
@@ -116,5 +117,17 @@ class ApiRoutesTest extends TestCase
         $this->putJson('/api/investors/' . $investor->id, ['nome' => 'Changed'])
             ->assertStatus(200);
         $this->deleteJson('/api/investors/' . $investor->id)->assertStatus(200);
+    }
+
+    public function test_transacao_financeira_resource_routes()
+    {
+        $this->withoutMiddleware();
+        $transacao = \App\Models\TransacaoFinanceira::factory()->create();
+
+        $this->getJson('/api/transacoes-financeiras')->assertStatus(200);
+        $this->getJson('/api/transacoes-financeiras/' . $transacao->id)->assertStatus(200);
+        $this->putJson('/api/transacoes-financeiras/' . $transacao->id, ['valor' => 50])
+            ->assertStatus(200);
+        $this->deleteJson('/api/transacoes-financeiras/' . $transacao->id)->assertStatus(200);
     }
 }

--- a/tests/Feature/TransacaoFinanceiraRegistrationTest.php
+++ b/tests/Feature/TransacaoFinanceiraRegistrationTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\Investor;
+
+class TransacaoFinanceiraRegistrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_transacao_financeira_can_be_registered(): void
+    {
+        $investor = Investor::factory()->create();
+
+        $response = $this->postJson('/api/transacoes-financeiras', [
+            'id_investidor' => $investor->id,
+            'tipo' => 'deposito',
+            'valor' => 100,
+            'status' => 'pendente',
+            'data_transacao' => now()->toDateTimeString(),
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('transacoes_financeiras', [
+            'id_investidor' => $investor->id,
+            'tipo' => 'deposito',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add migration for `transacoes_financeiras`
- create model and factory
- add controller with CRUD endpoints
- expose new routes and tests for transactions

## Testing
- `composer install --ignore-platform-reqs`
- `./vendor/bin/phpunit` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_68560ae15ca08328b76f0735b73c61e2