### PR TITLE
Add internal wallet logic

### DIFF
--- a/app/Http/Controllers/InvestorController.php
+++ b/app/Http/Controllers/InvestorController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Investor;
+use App\Models\CarteiraInterna;
 use Illuminate\Http\Request;
 
 class InvestorController extends Controller
@@ -57,6 +58,14 @@ class InvestorController extends Controller
         ]);
 
         $investor = Investor::create($data);
+
+        CarteiraInterna::create([
+            'id_investidor' => $investor->id,
+            'endereco_wallet' => $investor->carteira_blockchain,
+            'saldo_disponivel' => 0,
+            'saldo_bloqueado' => 0,
+            'saldo_tokenizado' => [],
+        ]);
 
         return response()->json($investor, 201);
     }

--- a/app/Http/Controllers/TransacaoFinanceiraController.php
+++ b/app/Http/Controllers/TransacaoFinanceiraController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\TransacaoFinanceira;
+use App\Models\CarteiraInterna;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 
@@ -31,6 +32,19 @@ class TransacaoFinanceiraController extends Controller
         ]);
         $data['id'] = (string) Str::uuid();
         $transacao = TransacaoFinanceira::create($data);
+
+        $carteira = CarteiraInterna::where('id_investidor', $data['id_investidor'])->first();
+
+        if ($carteira) {
+            if ($data['tipo'] === 'deposito') {
+                $carteira->saldo_disponivel += $data['valor'];
+            } elseif ($data['tipo'] === 'saque') {
+                $carteira->saldo_disponivel -= $data['valor'];
+            }
+
+            $carteira->save();
+        }
+
         return response()->json($transacao, 201);
     }
 

--- a/app/Models/CarteiraInterna.php
+++ b/app/Models/CarteiraInterna.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CarteiraInterna extends Model
+{
+    use HasFactory;
+
+    protected $table = 'carteiras_internas';
+
+    protected $fillable = [
+        'id_investidor',
+        'endereco_wallet',
+        'saldo_disponivel',
+        'saldo_bloqueado',
+        'saldo_tokenizado',
+    ];
+
+    protected $casts = [
+        'saldo_tokenizado' => 'array',
+    ];
+
+    public function investor()
+    {
+        return $this->belongsTo(Investor::class, 'id_investidor');
+    }
+}

--- a/database/factories/CarteiraInternaFactory.php
+++ b/database/factories/CarteiraInternaFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\CarteiraInterna;
+use App\Models\Investor;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class CarteiraInternaFactory extends Factory
+{
+    protected $model = CarteiraInterna::class;
+
+    public function definition()
+    {
+        return [
+            'id_investidor' => Investor::factory(),
+            'endereco_wallet' => $this->faker->sha256(),
+            'saldo_disponivel' => 0,
+            'saldo_bloqueado' => 0,
+            'saldo_tokenizado' => [],
+        ];
+    }
+}

--- a/database/migrations/2025_07_05_000000_create_carteiras_internas_table.php
+++ b/database/migrations/2025_07_05_000000_create_carteiras_internas_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('carteiras_internas', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('id_investidor')->constrained('investors');
+            $table->string('endereco_wallet')->nullable();
+            $table->decimal('saldo_disponivel', 15, 2)->default(0);
+            $table->decimal('saldo_bloqueado', 15, 2)->default(0);
+            $table->json('saldo_tokenizado')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('carteiras_internas');
+    }
+};

--- a/tests/Feature/InvestorRegistrationTest.php
+++ b/tests/Feature/InvestorRegistrationTest.php
@@ -20,5 +20,8 @@ class InvestorRegistrationTest extends TestCase
 
         $response->assertStatus(201);
         $this->assertDatabaseHas('investors', ['email' => 'john@example.com']);
+        $this->assertDatabaseHas('carteiras_internas', [
+            'id_investidor' => 1
+        ]);
     }
 }

--- a/tests/Feature/TransacaoFinanceiraRegistrationTest.php
+++ b/tests/Feature/TransacaoFinanceiraRegistrationTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use App\Models\Investor;
+use App\Models\CarteiraInterna;
 
 class TransacaoFinanceiraRegistrationTest extends TestCase
 {
@@ -13,6 +14,7 @@ class TransacaoFinanceiraRegistrationTest extends TestCase
     public function test_transacao_financeira_can_be_registered(): void
     {
         $investor = Investor::factory()->create();
+        CarteiraInterna::factory()->create(['id_investidor' => $investor->id]);
 
         $response = $this->postJson('/api/transacoes-financeiras', [
             'id_investidor' => $investor->id,
@@ -26,6 +28,11 @@ class TransacaoFinanceiraRegistrationTest extends TestCase
         $this->assertDatabaseHas('transacoes_financeiras', [
             'id_investidor' => $investor->id,
             'tipo' => 'deposito',
+        ]);
+
+        $this->assertDatabaseHas('carteiras_internas', [
+            'id_investidor' => $investor->id,
+            'saldo_disponivel' => 100,
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- create `carteiras_internas` table and model
- auto-create a wallet when registering an investor
- update wallet balance after a financial transaction
- expand feature tests to cover new behaviour

## Testing
- `composer test` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68561845d2b48328bd24568e0d96971a