### PR TITLE
Implement investments table and financial link

### DIFF
--- a/app/Http/Controllers/InvestmentController.php
+++ b/app/Http/Controllers/InvestmentController.php
@@ -3,12 +3,39 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\Investment;
+use App\Models\TransacaoFinanceira;
+use Illuminate\Support\Str;
 
 class InvestmentController extends Controller
 {
     public function purchase(Request $request)
     {
-        return response()->json(['message' => 'Purchase processed']);
+        $data = $request->validate([
+            'id_investidor' => 'required|integer|exists:investors,id',
+            'id_imovel' => 'required|integer|exists:properties,id',
+            'qtd_tokens' => 'required|integer|min:1',
+            'valor_unitario' => 'required|numeric',
+            'data_compra' => 'required|date',
+            'origem' => 'required|in:plataforma,p2p',
+            'status' => 'in:ativo,inativo',
+        ]);
+
+        $investment = Investment::create($data);
+
+        if ($data['origem'] === 'plataforma') {
+            TransacaoFinanceira::create([
+                'id' => (string) Str::uuid(),
+                'id_investidor' => $data['id_investidor'],
+                'tipo' => 'compra_token',
+                'valor' => $data['qtd_tokens'] * $data['valor_unitario'],
+                'status' => 'concluido',
+                'referencia' => 'investimento:' . $investment->id,
+                'data_transacao' => $data['data_compra'],
+            ]);
+        }
+
+        return response()->json($investment);
     }
 
     public function history()

--- a/app/Http/Controllers/TransacaoFinanceiraController.php
+++ b/app/Http/Controllers/TransacaoFinanceiraController.php
@@ -24,7 +24,7 @@ class TransacaoFinanceiraController extends Controller
     {
         $data = $request->validate([
             'id_investidor' => 'required|integer|exists:investors,id',
-            'tipo' => 'required|in:deposito,saque,rendimento,taxa',
+            'tipo' => 'required|in:deposito,saque,rendimento,taxa,compra_token',
             'valor' => 'required|numeric',
             'status' => 'in:pendente,concluido,falhou',
             'referencia' => 'nullable|string',
@@ -53,7 +53,7 @@ class TransacaoFinanceiraController extends Controller
         $transacao = TransacaoFinanceira::findOrFail($id);
         $data = $request->validate([
             'id_investidor' => 'sometimes|integer|exists:investors,id',
-            'tipo' => 'sometimes|in:deposito,saque,rendimento,taxa',
+            'tipo' => 'sometimes|in:deposito,saque,rendimento,taxa,compra_token',
             'valor' => 'sometimes|numeric',
             'status' => 'sometimes|in:pendente,concluido,falhou',
             'referencia' => 'nullable|string',

--- a/app/Models/Investment.php
+++ b/app/Models/Investment.php
@@ -10,12 +10,22 @@ class Investment extends Model
     use HasFactory;
 
     protected $fillable = [
-        'user_id',
-        'amount',
+        'id_investidor',
+        'id_imovel',
+        'qtd_tokens',
+        'valor_unitario',
+        'data_compra',
+        'origem',
+        'status',
     ];
 
-    public function user()
+    public function investor()
     {
-        return $this->belongsTo(User::class);
+        return $this->belongsTo(Investor::class, 'id_investidor');
+    }
+
+    public function property()
+    {
+        return $this->belongsTo(Property::class, 'id_imovel');
     }
 }

--- a/app/Models/Investor.php
+++ b/app/Models/Investor.php
@@ -17,4 +17,9 @@ class Investor extends Model
         'status_kyc',
         'carteira_blockchain',
     ];
+
+    public function investments()
+    {
+        return $this->hasMany(Investment::class, 'id_investidor');
+    }
 }

--- a/app/Models/Property.php
+++ b/app/Models/Property.php
@@ -26,4 +26,9 @@ class Property extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    public function investments()
+    {
+        return $this->hasMany(Investment::class, 'id_imovel');
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -44,10 +44,6 @@ class User extends Authenticatable implements JWTSubject
         return $this->hasMany(Kyc::class);
     }
 
-    public function investments() {
-        return $this->hasMany(Investment::class);
-    }
-
     public function properties() {
         return $this->hasMany(Property::class);
     }

--- a/database/factories/InvestmentFactory.php
+++ b/database/factories/InvestmentFactory.php
@@ -3,7 +3,8 @@
 namespace Database\Factories;
 
 use App\Models\Investment;
-use App\Models\User;
+use App\Models\Investor;
+use App\Models\Property;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class InvestmentFactory extends Factory
@@ -13,8 +14,13 @@ class InvestmentFactory extends Factory
     public function definition()
     {
         return [
-            'user_id' => User::factory(),
-            'amount' => $this->faker->randomFloat(2, 100, 1000),
+            'id_investidor' => Investor::factory(),
+            'id_imovel' => Property::factory(),
+            'qtd_tokens' => $this->faker->numberBetween(1, 100),
+            'valor_unitario' => $this->faker->randomFloat(2, 10, 1000),
+            'data_compra' => $this->faker->dateTime(),
+            'origem' => $this->faker->randomElement(['plataforma', 'p2p']),
+            'status' => 'ativo',
         ];
     }
 }

--- a/database/factories/PropertyFactory.php
+++ b/database/factories/PropertyFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Property;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class PropertyFactory extends Factory
+{
+    protected $model = Property::class;
+
+    public function definition()
+    {
+        return [
+            'titulo' => $this->faker->word(),
+            'descricao' => $this->faker->sentence(),
+            'localizacao' => $this->faker->city(),
+            'valor_total' => $this->faker->randomFloat(2, 10000, 100000),
+            'qtd_tokens' => $this->faker->numberBetween(1, 1000),
+            'modelo_smart_id' => null,
+            'status' => 'ativo',
+            'data_tokenizacao' => now(),
+            'user_id' => User::factory(),
+        ];
+    }
+}
+

--- a/database/factories/TransacaoFinanceiraFactory.php
+++ b/database/factories/TransacaoFinanceiraFactory.php
@@ -16,7 +16,7 @@ class TransacaoFinanceiraFactory extends Factory
         return [
             'id' => (string) Str::uuid(),
             'id_investidor' => Investor::factory(),
-            'tipo' => $this->faker->randomElement(['deposito','saque','rendimento','taxa']),
+            'tipo' => $this->faker->randomElement(['deposito','saque','rendimento','taxa','compra_token']),
             'valor' => $this->faker->randomFloat(2, 10, 1000),
             'status' => $this->faker->randomElement(['pendente','concluido','falhou']),
             'referencia' => $this->faker->sentence(),

--- a/database/migrations/2025_06_17_180004_create_investments_table.php
+++ b/database/migrations/2025_06_17_180004_create_investments_table.php
@@ -10,8 +10,13 @@ return new class extends Migration
     {
         Schema::create('investments', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained('users');
-            $table->decimal('amount', 15, 2);
+            $table->foreignId('id_investidor')->constrained('investors');
+            $table->foreignId('id_imovel')->constrained('properties');
+            $table->integer('qtd_tokens');
+            $table->decimal('valor_unitario', 15, 2);
+            $table->dateTime('data_compra');
+            $table->enum('origem', ['plataforma', 'p2p']);
+            $table->enum('status', ['ativo', 'inativo'])->default('ativo');
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_07_01_000000_create_transacoes_financeiras_table.php
+++ b/database/migrations/2025_07_01_000000_create_transacoes_financeiras_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
         Schema::create('transacoes_financeiras', function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->foreignId('id_investidor')->constrained('investors');
-            $table->enum('tipo', ['deposito', 'saque', 'rendimento', 'taxa']);
+            $table->enum('tipo', ['deposito', 'saque', 'rendimento', 'taxa', 'compra_token']);
             $table->decimal('valor', 15, 2);
             $table->enum('status', ['pendente', 'concluido', 'falhou'])->default('pendente');
             $table->text('referencia')->nullable();

--- a/tests/Feature/ApiRoutesTest.php
+++ b/tests/Feature/ApiRoutesTest.php
@@ -93,7 +93,18 @@ class ApiRoutesTest extends TestCase
     public function test_investment_routes()
     {
         $this->withoutMiddleware();
-        $this->postJson('/api/investments/purchase')->assertStatus(200);
+        $investor = \App\Models\Investor::factory()->create();
+        $property = \App\Models\Property::factory()->create();
+
+        $this->postJson('/api/investments/purchase', [
+            'id_investidor' => $investor->id,
+            'id_imovel' => $property->id,
+            'qtd_tokens' => 1,
+            'valor_unitario' => 10,
+            'data_compra' => now()->toDateTimeString(),
+            'origem' => 'plataforma',
+            'status' => 'ativo',
+        ])->assertStatus(200);
         $this->getJson('/api/investments/history')->assertStatus(200);
     }
 

--- a/tests/Unit/UserRelationshipTest.php
+++ b/tests/Unit/UserRelationshipTest.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use App\Models\Wallet;
 use App\Models\Kyc;
 use App\Models\Investment;
+use App\Models\Investor;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -30,12 +31,14 @@ class UserRelationshipTest extends TestCase
         $this->assertTrue($user->kyc->first()->is($kycs->first()));
     }
 
-    public function test_user_has_many_investments()
+    public function test_investor_has_many_investments()
     {
-        $user = User::factory()->create();
-        $investments = Investment::factory()->count(3)->create(['user_id' => $user->id]);
+        $investor = Investor::factory()->create();
+        $investments = Investment::factory()->count(3)->create([
+            'id_investidor' => $investor->id,
+        ]);
 
-        $this->assertCount(3, $user->investments);
-        $this->assertTrue($user->investments->first()->is($investments->first()));
+        $this->assertCount(3, $investor->investments);
+        $this->assertTrue($investor->investments->first()->is($investments->first()));
     }
 }


### PR DESCRIPTION
## Summary
- expand `investments` table with investor and property references
- support token purchase transactions
- adjust models and factories
- validate new investment purchase route
- update tests for new schema

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68561ed2ce4c8328b700821bb95b4f4a