### PR TITLE
Implement investor auth

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
 use App\Models\User;
+use App\Models\Investor;
+use Illuminate\Support\Facades\Hash;
 
 
 class AuthController extends Controller
@@ -43,5 +45,27 @@ public function login(Request $request)
         ]);
 
         return response()->json($user, 201);
+    }
+
+    public function loginInvestidor(Request $request)
+    {
+        $data = $request->validate([
+            'email' => 'required|email',
+            'senha' => 'required|string'
+        ]);
+
+        $investidor = Investor::where('email', $data['email'])->first();
+
+        if (!$investidor || !Hash::check($data['senha'], $investidor->senha_hash)) {
+            return response()->json(['message' => 'Credenciais inválidas'], 401);
+        }
+
+        $token = $investidor->createToken('investidor_token')->plainTextToken;
+
+        return response()->json([
+            'message' => 'Login realizado com sucesso',
+            'token' => $token,
+            'investidor' => $investidor
+        ]);
     }
 }

--- a/app/Http/Controllers/InvestorController.php
+++ b/app/Http/Controllers/InvestorController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Investor;
 use App\Models\CarteiraInterna;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Http\Request;
 
 class InvestorController extends Controller
@@ -53,11 +54,20 @@ class InvestorController extends Controller
             'email' => 'required|email|unique:investors,email',
             'documento' => 'required|string|max:50',
             'telefone' => 'nullable|string|max:30',
+            'senha' => 'required|string|min:6',
             'status_kyc' => 'in:pendente,aprovado,rejeitado',
             'carteira_blockchain' => 'nullable|string|max:255',
         ]);
 
-        $investor = Investor::create($data);
+        $investor = Investor::create([
+            'nome' => $data['nome'],
+            'email' => $data['email'],
+            'documento' => $data['documento'],
+            'telefone' => $data['telefone'],
+            'senha_hash' => Hash::make($data['senha']),
+            'status_kyc' => $data['status_kyc'] ?? 'pendente',
+            'carteira_blockchain' => $data['carteira_blockchain'] ?? null,
+        ]);
 
         CarteiraInterna::create([
             'id_investidor' => $investor->id,

--- a/app/Http/Controllers/P2PListingController.php
+++ b/app/Http/Controllers/P2PListingController.php
@@ -5,12 +5,15 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Models\P2PListing;
 use App\Models\Investment;
+use App\Http\Resources\P2PListingResource;
 
 class P2PListingController extends Controller
 {
     public function index()
     {
-        return response()->json(P2PListing::where('status', 'ativa')->get());
+        return P2PListingResource::collection(
+            P2PListing::where('status', 'ativa')->get()
+        );
     }
 
     public function store(Request $request)
@@ -31,7 +34,7 @@ class P2PListingController extends Controller
         }
 
         $listing = P2PListing::create($data);
-        return response()->json($listing, 201);
+        return new P2PListingResource($listing);
     }
 
     public function destroy($id)
@@ -39,6 +42,6 @@ class P2PListingController extends Controller
         $listing = P2PListing::findOrFail($id);
         $listing->status = 'cancelada';
         $listing->save();
-        return response()->json($listing);
+        return new P2PListingResource($listing);
     }
 }

--- a/app/Http/Resources/P2PListingResource.php
+++ b/app/Http/Resources/P2PListingResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class P2PListingResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'id_imovel' => $this->id_imovel,
+            'qtd_tokens' => $this->qtd_tokens,
+            'valor_unitario' => $this->valor_unitario,
+            'status' => $this->status,
+        ];
+    }
+}

--- a/app/Models/Investor.php
+++ b/app/Models/Investor.php
@@ -3,19 +3,25 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Laravel\Sanctum\HasApiTokens;
 
-class Investor extends Model
+class Investor extends Authenticatable
 {
-    use HasFactory;
+    use HasFactory, HasApiTokens;
 
     protected $fillable = [
         'nome',
         'email',
         'documento',
         'telefone',
+        'senha_hash',
         'status_kyc',
         'carteira_blockchain',
+    ];
+
+    protected $hidden = [
+        'senha_hash',
     ];
 
     public function investments()

--- a/database/factories/InvestorFactory.php
+++ b/database/factories/InvestorFactory.php
@@ -16,6 +16,7 @@ class InvestorFactory extends Factory
             'email' => $this->faker->unique()->safeEmail(),
             'documento' => (string) $this->faker->randomNumber(9, true),
             'telefone' => $this->faker->phoneNumber(),
+            'senha_hash' => bcrypt('password'),
             'status_kyc' => 'pendente',
             'carteira_blockchain' => $this->faker->sha256(),
         ];

--- a/database/migrations/2025_06_17_180002_create_investors_table.php
+++ b/database/migrations/2025_06_17_180002_create_investors_table.php
@@ -14,6 +14,7 @@ return new class extends Migration
             $table->string('email')->unique();
             $table->string('documento');
             $table->string('telefone')->nullable();
+            $table->string('senha_hash');
             $table->enum('status_kyc', ['pendente', 'aprovado', 'rejeitado'])->default('pendente');
             $table->string('carteira_blockchain')->nullable();
             $table->timestamps();

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,7 +29,17 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 });
 Route::post('auth/login', [AuthController::class, 'login']);
 Route::post('auth/register', [AuthController::class, 'register']);
+Route::post('/auth/investor-login', [AuthController::class, 'loginInvestidor']);
 Route::post('investors', [InvestorController::class, 'store']);
+
+Route::middleware(['auth:sanctum'])->group(function () {
+    Route::get('/me/investimentos', function (Request $request) {
+        return $request->user()->investments;
+    });
+
+    Route::get('/imoveis', [PropertyController::class, 'index']);
+    Route::get('/p2p/ofertas', [P2PListingController::class, 'index']);
+});
 Route::middleware(['auth:api'])->group(function() {
     Route::get('investors', [InvestorController::class, 'index']);
     Route::get('investors/{id}', [InvestorController::class, 'show']);

--- a/tests/Feature/InvestorRegistrationTest.php
+++ b/tests/Feature/InvestorRegistrationTest.php
@@ -16,6 +16,7 @@ class InvestorRegistrationTest extends TestCase
             'email' => 'john@example.com',
             'documento' => '12345678901',
             'telefone' => '123456789',
+            'senha' => 'secret123',
         ]);
 
         $response->assertStatus(201);


### PR DESCRIPTION
## Summary
- add password field to investors migration
- store hashed password when creating investors
- allow investors to log in and get sanctum token
- restrict investor routes with auth:sanctum
- return sanitized P2P listing data via resource
- update Investor factory and registration test

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685700c16e1c83289816b70a31934b81