### PR TITLE
Document entire API with Swagger annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,11 @@ If you discover a security vulnerability within Laravel, please send an e-mail t
 ## License
 
 The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
-# token
+
+## Swagger API Documentation
+
+Esta aplicação utiliza o pacote `l5-swagger` para gerar documentação no padrão OpenAPI.
+
+1. Instale as dependências do PHP com Composer.
+2. Execute `php artisan l5-swagger:generate` para gerar os arquivos de documentação.
+3. A interface poderá ser acessada em `/api/documentation` após iniciar o servidor.

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -6,12 +6,31 @@ use Illuminate\Http\Request;
 use App\Models\User;
 use App\Models\Investor;
 use Illuminate\Support\Facades\Hash;
+use OpenApi\Annotations as OA;
 
 
+/**
+ * @OA\Tag(
+ *     name="Auth",
+ *     description="Autenticação de usuários"
+ * )
+ */
 class AuthController extends Controller
 {
 
-public function login(Request $request)
+    /**
+     * Autenticar usuário e obter token JWT.
+     *
+     * @OA\Post(
+     *     path="/api/auth/login",
+     *     tags={"Auth"},
+     *     summary="Login de usuário",
+     *     @OA\RequestBody(required=true, @OA\JsonContent()),
+     *     @OA\Response(response=200, description="Sucesso"),
+     *     @OA\Response(response=401, description="Não autorizado")
+     * )
+     */
+    public function login(Request $request)
 {
     $credentials = $request->only(['email', 'password']);
 
@@ -26,6 +45,17 @@ public function login(Request $request)
     ]);
 }
 
+    /**
+     * Registrar novo usuário.
+     *
+     * @OA\Post(
+     *     path="/api/auth/register",
+     *     tags={"Auth"},
+     *     summary="Registrar usuário",
+     *     @OA\RequestBody(required=true, @OA\JsonContent()),
+     *     @OA\Response(response=201, description="Criado")
+     * )
+     */
     public function register(Request $request)
     {
         $data = $request->validate([
@@ -47,6 +77,18 @@ public function login(Request $request)
         return response()->json($user, 201);
     }
 
+    /**
+     * Login específico para investidores.
+     *
+     * @OA\Post(
+     *     path="/api/auth/investor-login",
+     *     tags={"Auth"},
+     *     summary="Login de investidor",
+     *     @OA\RequestBody(required=true, @OA\JsonContent()),
+     *     @OA\Response(response=200, description="Sucesso"),
+     *     @OA\Response(response=401, description="Não autorizado")
+     * )
+     */
     public function loginInvestidor(Request $request)
     {
         $data = $request->validate([

--- a/app/Http/Controllers/InvestmentController.php
+++ b/app/Http/Controllers/InvestmentController.php
@@ -7,9 +7,28 @@ use App\Models\Investment;
 use App\Models\TransacaoFinanceira;
 use App\Models\CarteiraInterna;
 use Illuminate\Support\Str;
+use OpenApi\Annotations as OA;
 
+/**
+ * @OA\Tag(
+ *     name="Investments",
+ *     description="Operações de investimentos"
+ * )
+ */
 class InvestmentController extends Controller
 {
+    /**
+     * Realizar compra de tokens de um imóvel.
+     *
+     * @OA\Post(
+     *     path="/api/investments/purchase",
+     *     tags={"Investments"},
+     *     security={{"sanctum":{}}},
+     *     summary="Comprar tokens",
+     *     @OA\RequestBody(required=true, @OA\JsonContent()),
+     *     @OA\Response(response=200, description="Sucesso")
+     * )
+     */
     public function purchase(Request $request)
     {
         $data = $request->validate([
@@ -50,6 +69,17 @@ class InvestmentController extends Controller
         return response()->json($investment);
     }
 
+    /**
+     * Histórico de investimentos do usuário autenticado.
+     *
+     * @OA\Get(
+     *     path="/api/investments/history",
+     *     tags={"Investments"},
+     *     security={{"sanctum":{}}},
+     *     summary="Histórico de investimentos",
+     *     @OA\Response(response=200, description="Sucesso")
+     * )
+     */
     public function history()
     {
         return response()->json([]);

--- a/app/Http/Controllers/InvestorController.php
+++ b/app/Http/Controllers/InvestorController.php
@@ -6,14 +6,45 @@ use App\Models\Investor;
 use App\Models\CarteiraInterna;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Http\Request;
+use OpenApi\Annotations as OA;
 
+/**
+ * @OA\Tag(
+ *     name="Investors",
+ *     description="Gerenciamento de investidores"
+ * )
+ */
 class InvestorController extends Controller
 {
+    /**
+     * Lista todos os investidores.
+     *
+     * @OA\Get(
+     *     path="/api/investors",
+     *     tags={"Investors"},
+     *     security={{"sanctum":{}}},
+     *     summary="Obter lista de investidores",
+     *     @OA\Response(response=200, description="Sucesso")
+     * )
+     */
     public function index()
     {
         return response()->json(Investor::all());
     }
 
+    /**
+     * Exibe um investidor específico.
+     *
+     * @OA\Get(
+     *     path="/api/investors/{id}",
+     *     tags={"Investors"},
+     *     security={{"sanctum":{}}},
+     *     summary="Detalhes do investidor",
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Sucesso"),
+     *     @OA\Response(response=404, description="Não encontrado")
+     * )
+     */
     public function show($id)
     {
         $investor = Investor::findOrFail($id);
@@ -21,6 +52,19 @@ class InvestorController extends Controller
         return response()->json($investor);
     }
 
+    /**
+     * Atualiza um investidor.
+     *
+     * @OA\Put(
+     *     path="/api/investors/{id}",
+     *     tags={"Investors"},
+     *     security={{"sanctum":{}}},
+     *     summary="Atualizar investidor",
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\RequestBody(required=true, @OA\JsonContent()),
+     *     @OA\Response(response=200, description="Atualizado")
+     * )
+     */
     public function update(Request $request, $id)
     {
         $investor = Investor::findOrFail($id);
@@ -39,6 +83,18 @@ class InvestorController extends Controller
         return response()->json($investor);
     }
 
+    /**
+     * Remove um investidor.
+     *
+     * @OA\Delete(
+     *     path="/api/investors/{id}",
+     *     tags={"Investors"},
+     *     security={{"sanctum":{}}},
+     *     summary="Excluir investidor",
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Excluído")
+     * )
+     */
     public function destroy($id)
     {
         $investor = Investor::findOrFail($id);
@@ -47,6 +103,17 @@ class InvestorController extends Controller
         return response()->json(['deleted' => true]);
     }
 
+    /**
+     * Cria um novo investidor.
+     *
+     * @OA\Post(
+     *     path="/api/investors",
+     *     tags={"Investors"},
+     *     summary="Cadastrar investidor",
+     *     @OA\RequestBody(required=true, @OA\JsonContent()),
+     *     @OA\Response(response=201, description="Criado")
+     * )
+     */
     public function store(Request $request)
     {
         $data = $request->validate([

--- a/app/Http/Controllers/P2PListingController.php
+++ b/app/Http/Controllers/P2PListingController.php
@@ -6,9 +6,27 @@ use Illuminate\Http\Request;
 use App\Models\P2PListing;
 use App\Models\Investment;
 use App\Http\Resources\P2PListingResource;
+use OpenApi\Annotations as OA;
 
+/**
+ * @OA\Tag(
+ *     name="P2P Listings",
+ *     description="Listagens de tokens para venda P2P"
+ * )
+ */
 class P2PListingController extends Controller
 {
+    /**
+     * Listar ofertas P2P ativas.
+     *
+     * @OA\Get(
+     *     path="/api/p2p/listings",
+     *     tags={"P2P Listings"},
+     *     security={{"sanctum":{}}},
+     *     summary="Listar ofertas",
+     *     @OA\Response(response=200, description="Sucesso")
+     * )
+     */
     public function index()
     {
         return P2PListingResource::collection(
@@ -16,6 +34,18 @@ class P2PListingController extends Controller
         );
     }
 
+    /**
+     * Criar nova oferta P2P.
+     *
+     * @OA\Post(
+     *     path="/api/p2p/listings",
+     *     tags={"P2P Listings"},
+     *     security={{"sanctum":{}}},
+     *     summary="Criar oferta",
+     *     @OA\RequestBody(required=true, @OA\JsonContent()),
+     *     @OA\Response(response=201, description="Criado")
+     * )
+     */
     public function store(Request $request)
     {
         $data = $request->validate([
@@ -37,6 +67,18 @@ class P2PListingController extends Controller
         return new P2PListingResource($listing);
     }
 
+    /**
+     * Cancelar uma oferta P2P.
+     *
+     * @OA\Delete(
+     *     path="/api/p2p/listings/{id}",
+     *     tags={"P2P Listings"},
+     *     security={{"sanctum":{}}},
+     *     summary="Cancelar oferta",
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Sucesso")
+     * )
+     */
     public function destroy($id)
     {
         $listing = P2PListing::findOrFail($id);

--- a/app/Http/Controllers/P2PTransactionController.php
+++ b/app/Http/Controllers/P2PTransactionController.php
@@ -8,9 +8,27 @@ use App\Models\P2PListing;
 use App\Models\TransacaoToken;
 use App\Models\Investment;
 use App\Models\CarteiraInterna;
+use OpenApi\Annotations as OA;
 
+/**
+ * @OA\Tag(
+ *     name="P2P Transactions",
+ *     description="Transações de compra e venda P2P"
+ * )
+ */
 class P2PTransactionController extends Controller
 {
+    /**
+     * Listar transações P2P.
+     *
+     * @OA\Get(
+     *     path="/api/p2p/transactions",
+     *     tags={"P2P Transactions"},
+     *     security={{"sanctum":{}}},
+     *     summary="Listar transações",
+     *     @OA\Response(response=200, description="Sucesso")
+     * )
+     */
     public function index(Request $request)
     {
         $id = $request->query('investidor_id');
@@ -23,6 +41,18 @@ class P2PTransactionController extends Controller
         return response()->json($query->get());
     }
 
+    /**
+     * Realizar transação de compra de oferta P2P.
+     *
+     * @OA\Post(
+     *     path="/api/p2p/transactions",
+     *     tags={"P2P Transactions"},
+     *     security={{"sanctum":{}}},
+     *     summary="Comprar oferta",
+     *     @OA\RequestBody(required=true, @OA\JsonContent()),
+     *     @OA\Response(response=201, description="Criada")
+     * )
+     */
     public function store(Request $request)
     {
         $data = $request->validate([

--- a/app/Http/Controllers/PropertyController.php
+++ b/app/Http/Controllers/PropertyController.php
@@ -4,20 +4,63 @@ namespace App\Http\Controllers;
 
 use App\Models\Property;
 use Illuminate\Http\Request;
+use OpenApi\Annotations as OA;
 
+/**
+ * @OA\Tag(
+ *     name="Properties",
+ *     description="Gerenciamento de imóveis"
+ * )
+ */
 class PropertyController extends Controller
 {
+    /**
+     * Listar imóveis cadastrados.
+     *
+     * @OA\Get(
+     *     path="/api/properties",
+     *     tags={"Properties"},
+     *     security={{"sanctum":{}}},
+     *     summary="Listar imóveis",
+     *     @OA\Response(response=200, description="Sucesso")
+     * )
+     */
     public function index()
     {
         return response()->json(Property::all());
     }
 
+    /**
+     * Exibir detalhes de um imóvel.
+     *
+     * @OA\Get(
+     *     path="/api/properties/{id}",
+     *     tags={"Properties"},
+     *     security={{"sanctum":{}}},
+     *     summary="Detalhes do imóvel",
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Sucesso")
+     * )
+     */
     public function show($id)
     {
         $property = Property::findOrFail($id);
         return response()->json($property);
     }
 
+    /**
+     * Atualizar dados de um imóvel.
+     *
+     * @OA\Put(
+     *     path="/api/properties/{id}",
+     *     tags={"Properties"},
+     *     security={{"sanctum":{}}},
+     *     summary="Atualizar imóvel",
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\RequestBody(required=true, @OA\JsonContent()),
+     *     @OA\Response(response=200, description="Sucesso")
+     * )
+     */
     public function update(Request $request, $id)
     {
         $property = Property::findOrFail($id);
@@ -36,6 +79,18 @@ class PropertyController extends Controller
         return response()->json($property);
     }
 
+    /**
+     * Remover um imóvel.
+     *
+     * @OA\Delete(
+     *     path="/api/properties/{id}",
+     *     tags={"Properties"},
+     *     security={{"sanctum":{}}},
+     *     summary="Excluir imóvel",
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Sucesso")
+     * )
+     */
     public function destroy($id)
     {
         $property = Property::findOrFail($id);
@@ -44,6 +99,18 @@ class PropertyController extends Controller
         return response()->json(['deleted' => true]);
     }
 
+    /**
+     * Cadastrar novo imóvel.
+     *
+     * @OA\Post(
+     *     path="/api/properties",
+     *     tags={"Properties"},
+     *     security={{"sanctum":{}}},
+     *     summary="Criar imóvel",
+     *     @OA\RequestBody(required=true, @OA\JsonContent()),
+     *     @OA\Response(response=201, description="Criado")
+     * )
+     */
     public function store(Request $request)
     {
         $data = $request->validate([
@@ -62,6 +129,18 @@ class PropertyController extends Controller
         return response()->json($property, 201);
     }
 
+    /**
+     * Listar tokens associados ao imóvel.
+     *
+     * @OA\Get(
+     *     path="/api/properties/{id}/tokens",
+     *     tags={"Properties"},
+     *     security={{"sanctum":{}}},
+     *     summary="Tokens do imóvel",
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Sucesso")
+     * )
+     */
     public function tokens($id)
     {
         return response()->json([

--- a/app/Http/Controllers/SupportTicketController.php
+++ b/app/Http/Controllers/SupportTicketController.php
@@ -3,29 +3,96 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use OpenApi\Annotations as OA;
 
+/**
+ * @OA\Tag(
+ *     name="Support Tickets",
+ *     description="Atendimento de suporte"
+ * )
+ */
 class SupportTicketController extends Controller
 {
+    /**
+     * Listar tickets de suporte.
+     *
+     * @OA\Get(
+     *     path="/api/support-tickets",
+     *     tags={"Support Tickets"},
+     *     security={{"sanctum":{}}},
+     *     summary="Listar tickets",
+     *     @OA\Response(response=200, description="Sucesso")
+     * )
+     */
     public function index()
     {
         return response()->json([]);
     }
 
+    /**
+     * Abrir novo ticket de suporte.
+     *
+     * @OA\Post(
+     *     path="/api/support-tickets",
+     *     tags={"Support Tickets"},
+     *     security={{"sanctum":{}}},
+     *     summary="Criar ticket",
+     *     @OA\RequestBody(required=true, @OA\JsonContent()),
+     *     @OA\Response(response=201, description="Criado")
+     * )
+     */
     public function store(Request $request)
     {
         return response()->json(['message' => 'Ticket created'], 201);
     }
 
+    /**
+     * Exibir ticket.
+     *
+     * @OA\Get(
+     *     path="/api/support-tickets/{id}",
+     *     tags={"Support Tickets"},
+     *     security={{"sanctum":{}}},
+     *     summary="Mostrar ticket",
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Sucesso")
+     * )
+     */
     public function show($id)
     {
         return response()->json(['id' => (int) $id]);
     }
 
+    /**
+     * Atualizar ticket.
+     *
+     * @OA\Put(
+     *     path="/api/support-tickets/{id}",
+     *     tags={"Support Tickets"},
+     *     security={{"sanctum":{}}},
+     *     summary="Atualizar ticket",
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\RequestBody(required=true, @OA\JsonContent()),
+     *     @OA\Response(response=200, description="Sucesso")
+     * )
+     */
     public function update(Request $request, $id)
     {
         return response()->json(['message' => 'Ticket updated']);
     }
 
+    /**
+     * Excluir ticket.
+     *
+     * @OA\Delete(
+     *     path="/api/support-tickets/{id}",
+     *     tags={"Support Tickets"},
+     *     security={{"sanctum":{}}},
+     *     summary="Excluir ticket",
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Sucesso")
+     * )
+     */
     public function destroy($id)
     {
         return response()->json(['message' => 'Ticket deleted']);

--- a/app/Http/Controllers/TransacaoFinanceiraController.php
+++ b/app/Http/Controllers/TransacaoFinanceiraController.php
@@ -6,20 +6,62 @@ use App\Models\TransacaoFinanceira;
 use App\Models\CarteiraInterna;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
+use OpenApi\Annotations as OA;
 
+/**
+ * @OA\Tag(
+ *     name="Financial Transactions",
+ *     description="Movimentações financeiras"
+ * )
+ */
 class TransacaoFinanceiraController extends Controller
 {
+    /**
+     * Listar transações financeiras.
+     *
+     * @OA\Get(
+     *     path="/api/transacoes-financeiras",
+     *     tags={"Financial Transactions"},
+     *     security={{"sanctum":{}}},
+     *     summary="Listar transações",
+     *     @OA\Response(response=200, description="Sucesso")
+     * )
+     */
     public function index()
     {
         return response()->json(TransacaoFinanceira::all());
     }
 
+    /**
+     * Mostrar uma transação específica.
+     *
+     * @OA\Get(
+     *     path="/api/transacoes-financeiras/{id}",
+     *     tags={"Financial Transactions"},
+     *     security={{"sanctum":{}}},
+     *     summary="Detalhes da transação",
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Sucesso")
+     * )
+     */
     public function show($id)
     {
         $transacao = TransacaoFinanceira::findOrFail($id);
         return response()->json($transacao);
     }
 
+    /**
+     * Criar nova transação financeira.
+     *
+     * @OA\Post(
+     *     path="/api/transacoes-financeiras",
+     *     tags={"Financial Transactions"},
+     *     security={{"sanctum":{}}},
+     *     summary="Registrar transação",
+     *     @OA\RequestBody(required=true, @OA\JsonContent()),
+     *     @OA\Response(response=201, description="Criada")
+     * )
+     */
     public function store(Request $request)
     {
         $data = $request->validate([
@@ -48,6 +90,19 @@ class TransacaoFinanceiraController extends Controller
         return response()->json($transacao, 201);
     }
 
+    /**
+     * Atualizar transação financeira.
+     *
+     * @OA\Put(
+     *     path="/api/transacoes-financeiras/{id}",
+     *     tags={"Financial Transactions"},
+     *     security={{"sanctum":{}}},
+     *     summary="Atualizar transação",
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\RequestBody(required=true, @OA\JsonContent()),
+     *     @OA\Response(response=200, description="Sucesso")
+     * )
+     */
     public function update(Request $request, $id)
     {
         $transacao = TransacaoFinanceira::findOrFail($id);
@@ -63,6 +118,18 @@ class TransacaoFinanceiraController extends Controller
         return response()->json($transacao);
     }
 
+    /**
+     * Remover transação financeira.
+     *
+     * @OA\Delete(
+     *     path="/api/transacoes-financeiras/{id}",
+     *     tags={"Financial Transactions"},
+     *     security={{"sanctum":{}}},
+     *     summary="Excluir transação",
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\Response(response=200, description="Sucesso")
+     * )
+     */
     public function destroy($id)
     {
         $transacao = TransacaoFinanceira::findOrFail($id);

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -3,9 +3,27 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use OpenApi\Annotations as OA;
 
+/**
+ * @OA\Tag(
+ *     name="Users",
+ *     description="Perfil do usuário autenticado"
+ * )
+ */
 class UserController extends Controller
 {
+    /**
+     * Recuperar dados do usuário logado.
+     *
+     * @OA\Get(
+     *     path="/api/user/profile",
+     *     tags={"Users"},
+     *     security={{"sanctum":{}}},
+     *     summary="Perfil do usuário",
+     *     @OA\Response(response=200, description="Sucesso")
+     * )
+     */
     public function profile(Request $request)
     {
         return response()->json($request->user() ?? []);

--- a/app/Http/Controllers/WalletController.php
+++ b/app/Http/Controllers/WalletController.php
@@ -3,19 +3,61 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use OpenApi\Annotations as OA;
 
+/**
+ * @OA\Tag(
+ *     name="Wallet",
+ *     description="Operações da carteira do investidor"
+ * )
+ */
 class WalletController extends Controller
 {
+    /**
+     * Exibe saldo da carteira.
+     *
+     * @OA\Get(
+     *     path="/api/wallet",
+     *     tags={"Wallet"},
+     *     security={{"sanctum":{}}},
+     *     summary="Consultar saldo",
+     *     @OA\Response(response=200, description="Sucesso")
+     * )
+     */
     public function show()
     {
         return response()->json(['balance' => 0]);
     }
 
+    /**
+     * Adicionar fundos à carteira.
+     *
+     * @OA\Post(
+     *     path="/api/wallet/add-funds",
+     *     tags={"Wallet"},
+     *     security={{"sanctum":{}}},
+     *     summary="Adicionar fundos",
+     *     @OA\RequestBody(required=true, @OA\JsonContent()),
+     *     @OA\Response(response=200, description="Sucesso")
+     * )
+     */
     public function addFunds(Request $request)
     {
         return response()->json(['message' => 'Funds added']);
     }
 
+    /**
+     * Solicitar saque de fundos.
+     *
+     * @OA\Post(
+     *     path="/api/wallet/withdraw",
+     *     tags={"Wallet"},
+     *     security={{"sanctum":{}}},
+     *     summary="Sacar fundos",
+     *     @OA\RequestBody(required=true, @OA\JsonContent()),
+     *     @OA\Response(response=200, description="Sucesso")
+     * )
+     */
     public function withdraw(Request $request)
     {
         return response()->json(['message' => 'Withdraw processed']);

--- a/app/Swagger/OpenApi.php
+++ b/app/Swagger/OpenApi.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Swagger;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Info(
+ *     title="Tokenization Platform API",
+ *     version="1.0.0",
+ *     description="Documentação da API da plataforma de tokenização"
+ * )
+ *
+ * @OA\Server(
+ *     url="/",
+ *     description="API Server"
+ * )
+ */
+class OpenApi {}

--- a/config/app.php
+++ b/config/app.php
@@ -159,6 +159,7 @@ return [
         /*
          * Package Service Providers...
          */
+        L5Swagger\L5SwaggerServiceProvider::class,
 
         /*
          * Application Service Providers...
@@ -183,6 +184,7 @@ return [
 
     'aliases' => Facade::defaultAliases()->merge([
         // 'Example' => App\Facades\Example::class,
+        'L5Swagger' => L5Swagger\Facades\L5Swagger::class,
     ])->toArray(),
 
 ];

--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -1,0 +1,292 @@
+<?php
+
+return [
+    'default' => 'default',
+    'documentations' => [
+        'default' => [
+            'api' => [
+                'title' => 'L5 Swagger UI',
+            ],
+
+            'routes' => [
+                /*
+                 * Route for accessing api documentation interface
+                 */
+                'api' => 'api/documentation',
+            ],
+            'paths' => [
+                /*
+                 * Edit to include full URL in ui for assets
+                 */
+                'use_absolute_path' => env('L5_SWAGGER_USE_ABSOLUTE_PATH', true),
+
+                /*
+                * Edit to set path where swagger ui assets should be stored
+                */
+                'swagger_ui_assets_path' => env('L5_SWAGGER_UI_ASSETS_PATH', 'vendor/swagger-api/swagger-ui/dist/'),
+
+                /*
+                 * File name of the generated json documentation file
+                 */
+                'docs_json' => 'api-docs.json',
+
+                /*
+                 * File name of the generated YAML documentation file
+                 */
+                'docs_yaml' => 'api-docs.yaml',
+
+                /*
+                 * Set this to `json` or `yaml` to determine which documentation file to use in UI
+                 */
+                'format_to_use_for_docs' => env('L5_FORMAT_TO_USE_FOR_DOCS', 'json'),
+
+                /*
+                 * Absolute paths to directory containing the swagger annotations are stored.
+                 */
+                'annotations' => [
+                    base_path('app'),
+                ],
+            ],
+        ],
+    ],
+    'defaults' => [
+        'routes' => [
+            /*
+             * Route for accessing parsed swagger annotations.
+             */
+            'docs' => 'docs',
+
+            /*
+             * Route for Oauth2 authentication callback.
+             */
+            'oauth2_callback' => 'api/oauth2-callback',
+
+            /*
+             * Middleware allows to prevent unexpected access to API documentation
+             */
+            'middleware' => [
+                'api' => [],
+                'asset' => [],
+                'docs' => [],
+                'oauth2_callback' => [],
+            ],
+
+            /*
+             * Route Group options
+             */
+            'group_options' => [],
+        ],
+
+        'paths' => [
+            /*
+             * Absolute path to location where parsed annotations will be stored
+             */
+            'docs' => storage_path('api-docs'),
+
+            /*
+             * Absolute path to directory where to export views
+             */
+            'views' => base_path('resources/views/vendor/l5-swagger'),
+
+            /*
+             * Edit to set the api's base path
+             */
+            'base' => env('L5_SWAGGER_BASE_PATH', null),
+
+            /*
+             * Absolute path to directories that should be excluded from scanning
+             * @deprecated Please use `scanOptions.exclude`
+             * `scanOptions.exclude` overwrites this
+             */
+            'excludes' => [],
+        ],
+
+        'scanOptions' => [
+            /**
+             * Configuration for default processors. Allows to pass processors configuration to swagger-php.
+             *
+             * @link https://zircote.github.io/swagger-php/reference/processors.html
+             */
+            'default_processors_configuration' => [
+            /** Example */
+            /**
+             * 'operationId.hash' => true,
+             * 'pathFilter' => [
+             * 'tags' => [
+             * '/pets/',
+             * '/store/',
+             * ],
+             * ],.
+             */
+            ],
+
+            /**
+             * analyser: defaults to \OpenApi\StaticAnalyser .
+             *
+             * @see \OpenApi\scan
+             */
+            'analyser' => null,
+
+            /**
+             * analysis: defaults to a new \OpenApi\Analysis .
+             *
+             * @see \OpenApi\scan
+             */
+            'analysis' => null,
+
+            /**
+             * Custom query path processors classes.
+             *
+             * @link https://github.com/zircote/swagger-php/tree/master/Examples/processors/schema-query-parameter
+             * @see \OpenApi\scan
+             */
+            'processors' => [
+                // new \App\SwaggerProcessors\SchemaQueryParameter(),
+            ],
+
+            /**
+             * pattern: string       $pattern File pattern(s) to scan (default: *.php) .
+             *
+             * @see \OpenApi\scan
+             */
+            'pattern' => null,
+
+            /*
+             * Absolute path to directories that should be excluded from scanning
+             * @note This option overwrites `paths.excludes`
+             * @see \OpenApi\scan
+             */
+            'exclude' => [],
+
+            /*
+             * Allows to generate specs either for OpenAPI 3.0.0 or OpenAPI 3.1.0.
+             * By default the spec will be in version 3.0.0
+             */
+            'open_api_spec_version' => env('L5_SWAGGER_OPEN_API_SPEC_VERSION', \L5Swagger\Generator::OPEN_API_DEFAULT_SPEC_VERSION),
+        ],
+
+        /*
+         * API security definitions. Will be generated into documentation file.
+        */
+        'securityDefinitions' => [
+            'securitySchemes' => [
+                /*
+                 * Examples of Security schemes
+                 */
+                /*
+                'api_key_security_example' => [ // Unique name of security
+                    'type' => 'apiKey', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'A short description for security scheme',
+                    'name' => 'api_key', // The name of the header or query parameter to be used.
+                    'in' => 'header', // The location of the API key. Valid values are "query" or "header".
+                ],
+                'oauth2_security_example' => [ // Unique name of security
+                    'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'A short description for oauth2 security scheme.',
+                    'flow' => 'implicit', // The flow used by the OAuth2 security scheme. Valid values are "implicit", "password", "application" or "accessCode".
+                    'authorizationUrl' => 'http://example.com/auth', // The authorization URL to be used for (implicit/accessCode)
+                    //'tokenUrl' => 'http://example.com/auth' // The authorization URL to be used for (password/application/accessCode)
+                    'scopes' => [
+                        'read:projects' => 'read your projects',
+                        'write:projects' => 'modify projects in your account',
+                    ]
+                ],
+                */
+
+                'sanctum' => [
+                    'type' => 'apiKey',
+                    'description' => 'Enter token in format (Bearer <token>)',
+                    'name' => 'Authorization',
+                    'in' => 'header',
+                ],
+            ],
+            'security' => [
+                [
+                    'sanctum' => [],
+                ],
+            ],
+        ],
+
+        /*
+         * Set this to `true` in development mode so that docs would be regenerated on each request
+         * Set this to `false` to disable swagger generation on production
+         */
+        'generate_always' => env('L5_SWAGGER_GENERATE_ALWAYS', false),
+
+        /*
+         * Set this to `true` to generate a copy of documentation in yaml format
+         */
+        'generate_yaml_copy' => env('L5_SWAGGER_GENERATE_YAML_COPY', false),
+
+        /*
+         * Edit to trust the proxy's ip address - needed for AWS Load Balancer
+         * string[]
+         */
+        'proxy' => false,
+
+        /*
+         * Configs plugin allows to fetch external configs instead of passing them to SwaggerUIBundle.
+         * See more at: https://github.com/swagger-api/swagger-ui#configs-plugin
+         */
+        'additional_config_url' => null,
+
+        /*
+         * Apply a sort to the operation list of each API. It can be 'alpha' (sort by paths alphanumerically),
+         * 'method' (sort by HTTP method).
+         * Default is the order returned by the server unchanged.
+         */
+        'operations_sort' => env('L5_SWAGGER_OPERATIONS_SORT', null),
+
+        /*
+         * Pass the validatorUrl parameter to SwaggerUi init on the JS side.
+         * A null value here disables validation.
+         */
+        'validator_url' => null,
+
+        /*
+         * Swagger UI configuration parameters
+         */
+        'ui' => [
+            'display' => [
+                'dark_mode' => env('L5_SWAGGER_UI_DARK_MODE', false),
+                /*
+                 * Controls the default expansion setting for the operations and tags. It can be :
+                 * 'list' (expands only the tags),
+                 * 'full' (expands the tags and operations),
+                 * 'none' (expands nothing).
+                 */
+                'doc_expansion' => env('L5_SWAGGER_UI_DOC_EXPANSION', 'none'),
+
+                /**
+                 * If set, enables filtering. The top bar will show an edit box that
+                 * you can use to filter the tagged operations that are shown. Can be
+                 * Boolean to enable or disable, or a string, in which case filtering
+                 * will be enabled using that string as the filter expression. Filtering
+                 * is case-sensitive matching the filter expression anywhere inside
+                 * the tag.
+                 */
+                'filter' => env('L5_SWAGGER_UI_FILTERS', true), // true | false
+            ],
+
+            'authorization' => [
+                /*
+                 * If set to true, it persists authorization data, and it would not be lost on browser close/refresh
+                 */
+                'persist_authorization' => env('L5_SWAGGER_UI_PERSIST_AUTHORIZATION', false),
+
+                'oauth2' => [
+                    /*
+                     * If set to true, adds PKCE to AuthorizationCodeGrant flow
+                     */
+                    'use_pkce_with_authorization_code_grant' => false,
+                ],
+            ],
+        ],
+        /*
+         * Constants which can be used in annotations
+         */
+        'constants' => [
+            'L5_SWAGGER_CONST_HOST' => env('L5_SWAGGER_CONST_HOST', 'http://my-default-host.com'),
+        ],
+    ],
+];


### PR DESCRIPTION
## Summary
- add OpenAPI info file for global API metadata
- annotate all controllers with Swagger tags and operations
- keep instructions on generating docs in README

## Testing
- `php --version` *(fails: command not found)*
- `composer --version` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68570cd1b640832881714e9a373b16c0