### PR TITLE
Fix investor login token handling

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -4,8 +4,6 @@ namespace App\Http\Controllers;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
 use App\Models\User;
-use App\Models\Investor;
-use Illuminate\Support\Facades\Hash;
 use OpenApi\Annotations as OA;
 
 
@@ -140,18 +138,16 @@ class AuthController extends Controller
             'senha' => 'required|string'
         ]);
 
-        $investidor = Investor::where('email', $data['email'])->first();
+        $credentials = ['email' => $data['email'], 'password' => $data['senha']];
 
-        if (!$investidor || !Hash::check($data['senha'], $investidor->senha_hash)) {
+        if (! $token = Auth::guard('investor')->attempt($credentials)) {
             return response()->json(['message' => 'Credenciais inválidas'], 401);
         }
-
-        $token = $investidor->createToken('investidor_token')->plainTextToken;
 
         return response()->json([
             'message' => 'Login realizado com sucesso',
             'token' => $token,
-            'investidor' => $investidor
+            'investidor' => Auth::guard('investor')->user(),
         ]);
     }
 }

--- a/app/Models/Investor.php
+++ b/app/Models/Investor.php
@@ -5,8 +5,9 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Laravel\Sanctum\HasApiTokens;
+use Tymon\JWTAuth\Contracts\JWTSubject;
 
-class Investor extends Authenticatable
+class Investor extends Authenticatable implements JWTSubject
 {
     use HasFactory, HasApiTokens;
 
@@ -27,5 +28,29 @@ class Investor extends Authenticatable
     public function investments()
     {
         return $this->hasMany(Investment::class, 'id_investidor');
+    }
+
+    /**
+     * Get the identifier that will be stored in the subject claim of the JWT.
+     */
+    public function getJWTIdentifier()
+    {
+        return $this->getKey();
+    }
+
+    /**
+     * Return a key value array, containing any custom claims to be added to the JWT.
+     */
+    public function getJWTCustomClaims()
+    {
+        return [];
+    }
+
+    /**
+     * Override the default password field for authentication.
+     */
+    public function getAuthPassword()
+    {
+        return $this->senha_hash;
     }
 }

--- a/config/auth.php
+++ b/config/auth.php
@@ -40,6 +40,10 @@ return [
         'driver' => 'jwt',
         'provider' => 'users',
     ],
+    'investor' => [
+        'driver' => 'jwt',
+        'provider' => 'investors',
+    ],
 ],
 
 
@@ -64,6 +68,11 @@ return [
         'users' => [
             'driver' => 'eloquent',
             'model' => App\Models\User::class,
+        ],
+
+        'investors' => [
+            'driver' => 'eloquent',
+            'model' => App\Models\Investor::class,
         ],
 
         // 'users' => [

--- a/routes/api.php
+++ b/routes/api.php
@@ -71,7 +71,7 @@ Route::middleware(['auth:sanctum'])->group(function () {
      */
     Route::get('/p2p/ofertas', [P2PListingController::class, 'index']);
 });
-Route::middleware(['auth:api'])->group(function() {
+Route::middleware(['auth:investor'])->group(function() {
     Route::get('investors', [InvestorController::class, 'index']);
     Route::get('investors/{id}', [InvestorController::class, 'show']);
     Route::put('investors/{id}', [InvestorController::class, 'update']);


### PR DESCRIPTION
## Summary
- issue JWT tokens for investors via a new `investor` guard
- implement JWTSubject in `Investor` model
- update auth config with investor guard and provider
- protect investor routes with the new guard

## Testing
- `php artisan test --testsuite Feature` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685760ed12d08328a15d37fcb1624a1e