### PR TITLE
Fix user seed hashing

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -26,7 +26,7 @@ class UserFactory extends Factory
         return [
             'nome' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
-            'password' => hash('sha256', 'password'),
+            'password' => bcrypt('password'),
             'tipo' => 'investidor',
             'status' => 'ativo',
             'status_kyc' => 'pendente',

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -12,7 +12,8 @@ class UserSeeder extends Seeder
         User::create([
             'nome' => 'wesley',
             'email' => 'wesley@ibsystem.com.br',
-            'password' => hash('sha256', '12345678'),
+            'password' => bcrypt('12345678'),
+            'tipo' => 'admin',
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- ensure seeded admin uses bcrypt password and set type
- use bcrypt for user factory passwords

## Testing
- `composer install --no-interaction --ignore-platform-reqs`
- `./vendor/bin/phpunit` *(fails: MissingAppKeyException, JWTException: Secret is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68578c861de08328ad89b142cf9f6b2c