### PR TITLE
Add admin financial report route

### DIFF
--- a/app/Http/Controllers/PropertyFinanceController.php
+++ b/app/Http/Controllers/PropertyFinanceController.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Property;
+use App\Models\Investment;
+use App\Models\TransacaoToken;
+use Illuminate\Support\Facades\DB;
+
+class PropertyFinanceController extends Controller
+{
+    public function report($id)
+    {
+        $property = Property::select(
+            'id',
+            'titulo',
+            'localizacao',
+            'valor_total',
+            'status',
+            'qtd_tokens_original',
+            'qtd_tokens'
+        )->find($id);
+
+        if (!$property) {
+            return response()->json(['message' => 'Imóvel não encontrado'], 404);
+        }
+
+        $tokensVendidos = $property->qtd_tokens_original - $property->qtd_tokens;
+
+        $investors = Investment::where('id_imovel', $id)
+            ->select('id_investidor', DB::raw('SUM(qtd_tokens) as total_tokens'))
+            ->groupBy('id_investidor')
+            ->with('investor:id,nome,email,documento')
+            ->get()
+            ->map(function ($inv) {
+                return [
+                    'id_investidor' => $inv->id_investidor,
+                    'nome' => $inv->investor->nome ?? null,
+                    'email' => $inv->investor->email ?? null,
+                    'documento' => $inv->investor->documento ?? null,
+                    'qtd_tokens' => $inv->total_tokens,
+                ];
+            });
+
+        $investments = Investment::where('id_imovel', $id)
+            ->with('investor:id,nome')
+            ->get()
+            ->map(function ($inv) {
+                return [
+                    'data_compra' => $inv->data_compra,
+                    'id_investidor' => $inv->id_investidor,
+                    'nome_investidor' => $inv->investor->nome ?? null,
+                    'qtd_tokens' => $inv->qtd_tokens,
+                    'valor_unitario' => $inv->valor_unitario,
+                    'origem' => $inv->origem,
+                    'status' => $inv->status,
+                ];
+            });
+
+        $p2p = TransacaoToken::where('id_imovel', $id)
+            ->with([
+                'vendedor:id,nome,email',
+                'comprador:id,nome,email'
+            ])
+            ->get()
+            ->map(function ($t) {
+                return [
+                    'vendedor' => [
+                        'nome' => $t->vendedor->nome ?? null,
+                        'email' => $t->vendedor->email ?? null,
+                    ],
+                    'comprador' => [
+                        'nome' => $t->comprador->nome ?? null,
+                        'email' => $t->comprador->email ?? null,
+                    ],
+                    'qtd_tokens' => $t->qtd_tokens,
+                    'valor_unitario' => $t->valor_unitario,
+                    'data_transacao' => $t->data_transacao,
+                    'tx_hash' => $t->tx_hash,
+                ];
+            });
+
+        return response()->json([
+            'resumo' => [
+                'tokens_vendidos' => $tokensVendidos,
+                'investidores_unicos' => $investors->count(),
+            ],
+            'imovel' => [
+                'titulo' => $property->titulo,
+                'localizacao' => $property->localizacao,
+                'valor_total' => $property->valor_total,
+                'status' => $property->status,
+                'qtd_tokens_original' => $property->qtd_tokens_original,
+                'qtd_tokens' => $property->qtd_tokens,
+            ],
+            'investidores' => $investors,
+            'investimentos' => $investments,
+            'transacoes_p2p' => $p2p,
+        ]);
+    }
+}
+

--- a/app/Models/TransacaoToken.php
+++ b/app/Models/TransacaoToken.php
@@ -25,4 +25,19 @@ class TransacaoToken extends Model
         'tx_hash',
         'status',
     ];
+
+    public function vendedor()
+    {
+        return $this->belongsTo(Investor::class, 'vendedor_id');
+    }
+
+    public function comprador()
+    {
+        return $this->belongsTo(Investor::class, 'comprador_id');
+    }
+
+    public function property()
+    {
+        return $this->belongsTo(Property::class, 'id_imovel');
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\SupportTicketController;
 use App\Http\Controllers\TransacaoFinanceiraController;
 use App\Http\Controllers\P2PListingController;
 use App\Http\Controllers\P2PTransactionController;
+use App\Http\Controllers\PropertyFinanceController;
 
 /*
 |--------------------------------------------------------------------------
@@ -82,6 +83,7 @@ Route::middleware(['auth:api','isAdmin'])->group(function() {
     Route::resource('properties', PropertyController::class);
     Route::get('properties/{id}/tokens', [PropertyController::class, 'tokens']);
     Route::get('user/profile', [UserController::class, 'profile']);
+    Route::get('admin/imoveis/{id}/financeiro', [PropertyFinanceController::class, 'report']);
 });
 
 // Funcionalidades disponíveis para investidores autenticados

--- a/tests/Feature/PropertyFinanceReportTest.php
+++ b/tests/Feature/PropertyFinanceReportTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Property;
+use App\Models\Investor;
+use App\Models\Investment;
+
+class PropertyFinanceReportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_view_property_financial_report(): void
+    {
+        $this->withoutMiddleware();
+        $admin = User::factory()->create(['tipo' => 'admin']);
+        $property = Property::factory()->create([
+            'user_id' => $admin->id,
+            'qtd_tokens_original' => 100,
+            'qtd_tokens' => 80,
+        ]);
+
+        $investor = Investor::factory()->create();
+        Investment::factory()->create([
+            'id_investidor' => $investor->id,
+            'id_imovel' => $property->id,
+            'qtd_tokens' => 20,
+            'valor_unitario' => 5,
+        ]);
+
+        $response = $this->getJson('/api/admin/imoveis/' . $property->id . '/financeiro');
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['tokens_vendidos' => 20]);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add relationships for `TransacaoToken`
- implement `PropertyFinanceController` with financial report logic
- expose new route `admin/imoveis/{id}/financeiro`
- add feature test for financial report route

## Testing
- `./vendor/bin/phpunit --filter=PropertyFinanceReportTest --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6858aeaf1abc83288001b4b176dd0db1