### PR TITLE
Fix private key generation

### DIFF
--- a/database/factories/InvestorFactory.php
+++ b/database/factories/InvestorFactory.php
@@ -19,7 +19,7 @@ class InvestorFactory extends Factory
             'senha_hash' => bcrypt('password'),
             'status_kyc' => 'pendente',
             'carteira_blockchain' => $this->faker->sha256(),
-            'carteira_private_key' => $this->faker->sha256(),
+            'carteira_private_key' => bin2hex(random_bytes(32)),
         ];
     }
 }

--- a/database/factories/WalletFactory.php
+++ b/database/factories/WalletFactory.php
@@ -15,7 +15,7 @@ class WalletFactory extends Factory
         return [
             'user_id' => User::factory(),
             'polygon_address' => $this->faker->regexify('[A-Fa-f0-9]{40}'),
-            'private_key_enc' => $this->faker->sha256(),
+            'private_key_enc' => bin2hex(random_bytes(32)),
             'saldo' => $this->faker->randomFloat(8, 0, 1000),
         ];
     }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -22,7 +22,7 @@ class UserSeeder extends Seeder
         Wallet::create([
             'user_id' => $user->id,
             'polygon_address' => '0x' . Str::random(40),
-            'private_key_enc' => Crypt::encryptString(Str::random(64)),
+            'private_key_enc' => Crypt::encryptString(bin2hex(random_bytes(32))),
             'saldo' => 0,
         ]);
     }


### PR DESCRIPTION
## Summary
- use `bin2hex(random_bytes(32))` for private keys in `UserSeeder`
- update factories to generate hex-encoded private keys
- reseed database with new keys

## Testing
- `composer install --ignore-platform-reqs`
- `php artisan migrate:fresh --seed`
- `./vendor/bin/phpunit` *(fails: Tests: 21, Assertions: 37, Errors: 1, Failures: 8)*

------
https://chatgpt.com/codex/tasks/task_e_685c3076fec48328b640c290ab7dfd6c