### PR TITLE
Add metaTransfer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,13 @@ Esta aplicação utiliza o pacote `l5-swagger` para gerar documentação no padr
 1. Instale as dependências do PHP com Composer.
 2. Execute `php artisan l5-swagger:generate` para gerar os arquivos de documentação.
 3. A interface poderá ser acessada em `/api/documentation` após iniciar o servidor.
+
+## Meta-transaction Relayer
+
+Para que os investidores possam transferir tokens sem pagar gás, utilize o script `relay_meta_transfer.js`. Ele assina a intenção com a chave do investidor e envia a transação usando a carteira do proprietário.
+
+```
+node scripts/relay_meta_transfer.js <enderecoContrato> <caminhoABI> <chaveInvestidor> <chaveRelayer> <destino> <quantidade>
+```
+
+A variável de ambiente `POLYGON_RPC_URL` deve apontar para o nó da rede.

--- a/contracts/FractionalPropertyToken.sol
+++ b/contracts/FractionalPropertyToken.sol
@@ -9,6 +9,10 @@ contract FractionalPropertyToken {
     uint256 public buybackPrice;
     bool public buybackEnabled;
 
+    mapping(address => uint256) public nonces;
+
+    event MetaTransfer(address indexed relayer, address indexed from, address indexed to, uint256 value);
+
     mapping(address => uint256) public balanceOf;
     mapping(address => mapping(address => uint256)) public allowance;
 
@@ -57,6 +61,36 @@ contract FractionalPropertyToken {
         balanceOf[to] += value;
         emit Transfer(from, to, value);
         emit Approval(from, msg.sender, allowance[from][msg.sender]);
+        return true;
+    }
+
+    function metaTransfer(
+        address from,
+        address to,
+        uint256 value,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public returns (bool) {
+        require(to != address(0), "invalid to");
+
+        bytes32 messageHash = keccak256(
+            abi.encodePacked(address(this), from, to, value, nonces[from])
+        );
+        bytes32 ethSignedMessageHash = keccak256(
+            abi.encodePacked("\x19Ethereum Signed Message:\n32", messageHash)
+        );
+        address signer = ecrecover(ethSignedMessageHash, v, r, s);
+        require(signer == from, "invalid signature");
+
+        require(balanceOf[from] >= value, "balance too low");
+
+        nonces[from] += 1;
+
+        balanceOf[from] -= value;
+        balanceOf[to] += value;
+        emit Transfer(from, to, value);
+        emit MetaTransfer(msg.sender, from, to, value);
         return true;
     }
 

--- a/scripts/relay_meta_transfer.js
+++ b/scripts/relay_meta_transfer.js
@@ -1,0 +1,41 @@
+import { ethers } from 'ethers';
+import fs from 'fs';
+
+const rpcUrl = process.env.POLYGON_RPC_URL;
+
+async function main() {
+  const [contractAddress, abiPath, investorKey, relayerKey, to, amount] = process.argv.slice(2);
+  if (!contractAddress || !abiPath || !investorKey || !relayerKey || !to || !amount) {
+    console.error('Usage: node relay_meta_transfer.js <contractAddress> <abiPath> <investorKey> <relayerKey> <to> <amount>');
+    process.exit(1);
+  }
+
+  const abi = JSON.parse(fs.readFileSync(abiPath, 'utf8'));
+  const provider = new ethers.JsonRpcProvider(rpcUrl);
+  const investorWallet = new ethers.Wallet(investorKey, provider);
+  const relayerWallet = new ethers.Wallet(relayerKey, provider);
+  const contract = new ethers.Contract(contractAddress, abi, provider);
+
+  const nonce = await contract.nonces(investorWallet.address);
+  const messageHash = ethers.solidityPackedKeccak256(
+    ['address', 'address', 'address', 'uint256', 'uint256'],
+    [contractAddress, investorWallet.address, to, amount, nonce]
+  );
+
+  const signature = await investorWallet.signMessage(ethers.getBytes(messageHash));
+  const sig = ethers.Signature.from(signature);
+
+  const relayerContract = contract.connect(relayerWallet);
+  const tx = await relayerContract.metaTransfer(
+    investorWallet.address,
+    to,
+    amount,
+    sig.v,
+    sig.r,
+    sig.s
+  );
+  await tx.wait();
+  console.log(JSON.stringify({ txHash: tx.hash }));
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- enable meta-transactions in `FractionalPropertyToken`
- add `relay_meta_transfer.js` script so the contract owner can relay signed transfers
- document how to use the relayer

## Testing
- `php artisan test` *(fails: command not found)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685dd3b5fa848328b35d3700339b314d