### PR TITLE
Update buyback token contract with meta-transfer support

### DIFF
--- a/database/migrations/2025_07_10_000000_update_buyback_contract_add_metatransfer.php
+++ b/database/migrations/2025_07_10_000000_update_buyback_contract_add_metatransfer.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        $path = base_path('contracts/FractionalPropertyToken.sol');
+        $code = file_exists($path) ? file_get_contents($path) : null;
+
+        if ($code) {
+            DB::table('smart_contract_models')
+                ->where('type', 'erc20_buyback')
+                ->update([
+                    'solidity_code' => $code,
+                    'version' => '0.8.20',
+                ]);
+        }
+    }
+
+    public function down()
+    {
+        // No rollback
+    }
+};


### PR DESCRIPTION
## Summary
- update `SmartContractModelSeeder` to seed Solidity code including `nonces` and `metaTransfer`
- add migration updating existing buyback smart contract model

## Testing
- `npm install`
- `node -e "import fs from 'fs';import solc from 'solc';const source=fs.readFileSync('contracts/FractionalPropertyToken.sol','utf8');const input={language:'Solidity',sources:{'Token.sol':{content:source}},settings:{outputSelection:{'*':{'*':['abi']}}}};const output=JSON.parse(solc.compile(JSON.stringify(input)));const contractName=Object.keys(output.contracts['Token.sol'])[0];const abi=output.contracts['Token.sol'][contractName].abi;console.log(abi.map(f=>f.name).join(','));" | grep -o 'metaTransfer' -n

------
https://chatgpt.com/codex/tasks/task_e_685f08eff61083288d0a90b3270a3b63