### PR TITLE
Remove unused useRelayer variable

### DIFF
--- a/app/Http/Controllers/P2PTransactionController.php
+++ b/app/Http/Controllers/P2PTransactionController.php
@@ -145,7 +145,6 @@ class P2PTransactionController extends Controller
                 $abiPath = storage_path('app/'.uniqid('abi_').'.json');
                 file_put_contents($abiPath, $property->contract_abi);
 
-                $useRelayer = false;
                 $buyerBalance = 0;
                 if ($buyer->carteira_blockchain) {
                     $resp = Http::get('https://api.polygonscan.com/api', [


### PR DESCRIPTION
## Summary
- clean up `P2PTransactionController` by deleting the unused `$useRelayer` variable

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f08f6438c8328a9084cb1b0aa63f2