### PR TITLE
Update P2P relayer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,6 @@ A rota `api/p2p/transactions` verifica o saldo em MATIC da carteira do
 comprador. Se o saldo for zero, a transferência de tokens do vendedor para o
 comprador é feita usando meta‑transação, assinada pelo vendedor e enviada pela
 carteira do proprietário do contrato por meio do script `relay_meta_transfer.js`.
+Para utilizar o relayer, os imóveis devem ser implantados com um contrato que
+inclua as funções `metaTransfer` e `nonces`. Contratos implantados antes dessa
+mudança precisam ser atualizados ou não funcionarão com o relayer.


### PR DESCRIPTION
## Summary
- document that P2P relayer requires contracts with `metaTransfer` and `nonces`
- warn that old deployments must be upgraded

## Testing
- `composer install --no-interaction --no-progress` *(fails: command not found)*
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685f08fbf3588328926c69f5083f48bf