### PR TITLE
Fix token amount conversion for blockchain transfers

### DIFF
--- a/app/Http/Controllers/InvestmentController.php
+++ b/app/Http/Controllers/InvestmentController.php
@@ -123,13 +123,14 @@ class InvestmentController extends Controller
                 $abiPath = storage_path('app/' . uniqid('abi_') . '.json');
                 file_put_contents($abiPath, $property->contract_abi);
 
+                $tokenAmount = bcmul((string) $investment->qtd_tokens, '1000000000000000000');
                 $process = new Process([
                     'node', base_path('scripts/transfer_token.js'),
                     $property->contract_address,
                     $abiPath,
                     $privKey,
                     $investor->carteira_blockchain,
-                    $investment->qtd_tokens,
+                    $tokenAmount,
                 ]);
                 $process->run();
                 if ($process->isSuccessful()) {

--- a/app/Http/Controllers/P2PTransactionController.php
+++ b/app/Http/Controllers/P2PTransactionController.php
@@ -163,6 +163,7 @@ class P2PTransactionController extends Controller
 
                 if ($buyerBalance <= 0 && $property->user && $property->user->wallet) {
                     $relayerKey = Crypt::decryptString($property->user->wallet->private_key_enc);
+                    $tokenAmount = bcmul((string) $listing->qtd_tokens, '1000000000000000000');
                     $process = new Process([
                         'node', base_path('scripts/relay_meta_transfer.js'),
                         $property->contract_address,
@@ -170,16 +171,17 @@ class P2PTransactionController extends Controller
                         $privKey,
                         $relayerKey,
                         $buyer->carteira_blockchain,
-                        $listing->qtd_tokens,
+                        $tokenAmount,
                     ]);
                 } else {
+                    $tokenAmount = bcmul((string) $listing->qtd_tokens, '1000000000000000000');
                     $process = new Process([
                         'node', base_path('scripts/transfer_token.js'),
                         $property->contract_address,
                         $abiPath,
                         $privKey,
                         $buyer->carteira_blockchain,
-                        $listing->qtd_tokens,
+                        $tokenAmount,
                     ]);
                 }
                 $process->run();


### PR DESCRIPTION
## Summary
- convert token amounts to smallest unit before invoking transfer scripts

## Testing
- `npm test` *(fails: Missing script)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f10d39b7c832893a627042fc5a0ec