### PR TITLE
Implement admin buyback backend support

### DIFF
--- a/app/Http/Controllers/BuybackController.php
+++ b/app/Http/Controllers/BuybackController.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Property;
+use App\Models\Investor;
+use App\Models\CarteiraInterna;
+use App\Models\TransacaoFinanceira;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Crypt;
+use Symfony\Component\Process\Process;
+use App\Helpers\LogTransacaoHelper;
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Tag(
+ *     name="Buyback",
+ *     description="Recompra administrativa de tokens"
+ * )
+ */
+class BuybackController extends Controller
+{
+    /**
+     * Processar recompra de tokens dos investidores.
+     *
+     * @OA\Post(
+     *     path="/api/admin/imoveis/{id}/buyback",
+     *     tags={"Buyback"},
+     *     security={{"sanctum":{}}},
+     *     summary="Recomprar tokens dos investidores",
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             @OA\Property(
+     *                 property="valor_pago",
+     *                 type="number",
+     *                 description="Valor a ser pago por token"
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=200, description="Sucesso")
+     * )
+     */
+    public function buyback(Request $request, $id)
+    {
+        $property = Property::with('investments')->findOrFail($id);
+
+        $data = $request->validate([
+            'valor_pago' => 'required|numeric',
+        ]);
+
+        $addresses = [];
+        $amounts = [];
+
+        $investmentData = $property->investments()
+            ->selectRaw('id_investidor, SUM(qtd_tokens) as total_tokens')
+            ->groupBy('id_investidor')
+            ->get();
+
+        foreach ($investmentData as $info) {
+            $investor = Investor::find($info->id_investidor);
+            if (!$investor) {
+                continue;
+            }
+
+            $payout = $info->total_tokens * $data['valor_pago'];
+
+            $wallet = CarteiraInterna::where('id_investidor', $investor->id)->lockForUpdate()->first();
+            if ($wallet) {
+                $wallet->saldo_disponivel += $payout;
+                $wallet->save();
+            }
+
+            TransacaoFinanceira::create([
+                'id' => (string) Str::uuid(),
+                'id_investidor' => $investor->id,
+                'tipo' => 'rendimento',
+                'valor' => $payout,
+                'status' => 'concluido',
+                'referencia' => 'buyback:' . $property->id,
+                'data_transacao' => now(),
+            ]);
+
+            if ($investor->carteira_blockchain) {
+                $addresses[] = $investor->carteira_blockchain;
+                $amounts[] = bcmul((string) $info->total_tokens, '1000000000000000000');
+            }
+        }
+
+        if (
+            $property->contract_address &&
+            $property->contract_abi &&
+            $property->user &&
+            $property->user->wallet &&
+            !empty($addresses)
+        ) {
+            try {
+                $privKey = Crypt::decryptString($property->user->wallet->private_key_enc);
+                $abiPath = storage_path('app/' . uniqid('abi_') . '.json');
+                file_put_contents($abiPath, $property->contract_abi);
+
+                $process = new Process([
+                    'node', base_path('scripts/admin_buyback.js'),
+                    $property->contract_address,
+                    $abiPath,
+                    $privKey,
+                    implode(',', $addresses),
+                    implode(',', $amounts),
+                ]);
+                $process->run();
+                @unlink($abiPath);
+            } catch (\Exception $e) {
+                LogTransacaoHelper::registrar('admin_buyback_error', ['error' => $e->getMessage()], auth('api')->user(), $property->id);
+            }
+        }
+
+        $property->status = 'vendido';
+        $property->save();
+
+        LogTransacaoHelper::registrar('admin_buyback', $data, auth('api')->user(), $property->id);
+
+        return response()->json(['status' => 'success']);
+    }
+}

--- a/contracts/AdminBuybackExample.md
+++ b/contracts/AdminBuybackExample.md
@@ -1,0 +1,72 @@
+# Admin Buyback Function Example
+
+The `adminBuyback` function allows the contract owner to transfer tokens from multiple investors back to the owner address. Payments to investors are handled off‑chain via the Laravel backend.
+
+## Solidity Function Signature
+```solidity
+function adminBuyback(address[] calldata investors, uint256[] calldata amounts) external onlyOwner
+```
+
+## Example JSON Payload from Laravel
+```json
+{
+  "contract": "0xContractAddress",
+  "method": "adminBuyback",
+  "params": {
+    "investors": [
+      "0xInvestor1",
+      "0xInvestor2"
+    ],
+    "amounts": [
+      "1000000000000000000",
+      "2000000000000000000"
+    ]
+  }
+}
+```
+
+## Pseudocode Call in Laravel
+```php
+$contract->adminBuyback(
+    [$investor1, $investor2],
+    [$amount1, $amount2],
+    ['from' => $ownerAddress]
+);
+```
+
+## Backend API Example
+
+Use the following request to execute a buyback from Laravel:
+
+```json
+{
+  "valor_pago": 25.0
+}
+```
+
+The `valor_pago` field represents the amount paid per token. The controller
+automatically locates all investors who hold tokens for the given property,
+credits their internal wallets with `qtd_tokens * valor_pago`, logs the
+corresponding financial transactions and marks the property as `vendido`.
+
+The controller credits the investor's internal wallet with the paid amount, logs a `rendimento` entry in `transacoes_financeiras`, and marks the property as `vendido`.
+
+## Testing with Postman
+
+You can manually trigger a buyback using the authenticated admin route:
+
+```
+POST /api/admin/imoveis/{id}/buyback
+Authorization: Bearer <ADMIN_TOKEN>
+Content-Type: application/json
+
+{
+  "valor_pago": 25.0
+}
+```
+
+Replace `{id}` with the property identifier and provide a valid admin bearer token in the `Authorization` header. The response will be:
+
+```json
+{ "status": "success" }
+```

--- a/contracts/FractionalPropertyToken.sol
+++ b/contracts/FractionalPropertyToken.sol
@@ -128,6 +128,31 @@ contract FractionalPropertyToken {
         emit BuybackDisabled();
     }
 
+    /**
+     * @dev Admin can forcefully buy back tokens from a list of investors.
+     *      Payments are handled off-chain. This function only moves tokens
+     *      back to the contract owner and emits standard Transfer events.
+     * @param investors Array of investor addresses.
+     * @param amounts   Corresponding token amounts to be transferred.
+     */
+    function adminBuyback(
+        address[] calldata investors,
+        uint256[] calldata amounts
+    ) external onlyOwner {
+        require(investors.length == amounts.length, "length mismatch");
+
+        for (uint256 i = 0; i < investors.length; i++) {
+            address investor = investors[i];
+            uint256 amount = amounts[i];
+            require(investor != address(0), "invalid investor");
+            require(balanceOf[investor] >= amount, "balance too low");
+
+            balanceOf[investor] -= amount;
+            balanceOf[owner] += amount;
+            emit Transfer(investor, owner, amount);
+        }
+    }
+
     function sellTokens(uint256 amount) external {
         require(buybackEnabled, "buyback not enabled");
         require(balanceOf[msg.sender] >= amount, "balance too low");

--- a/routes/api.php
+++ b/routes/api.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\SupportTicketController;
 use App\Http\Controllers\TransacaoFinanceiraController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\WalletController;
+use App\Http\Controllers\BuybackController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -88,6 +89,7 @@ Route::middleware(['auth:api', 'isAdmin'])->group(function () {
     Route::post('properties/{id}/tokenize', [PropertyController::class, 'tokenize']);
     Route::get('user/profile', [UserController::class, 'profile']);
     Route::get('admin/imoveis/{id}/financeiro', [PropertyFinanceController::class, 'report']);
+    Route::post('admin/imoveis/{id}/buyback', [BuybackController::class, 'buyback']);
 });
 
 // Funcionalidades disponíveis para investidores autenticados

--- a/scripts/admin_buyback.js
+++ b/scripts/admin_buyback.js
@@ -1,0 +1,23 @@
+import { ethers } from 'ethers';
+import fs from 'fs';
+
+const rpcUrl = process.env.POLYGON_RPC_URL;
+
+async function main() {
+  const [contractAddress, abiPath, ownerKey, investorsCsv, amountsCsv] = process.argv.slice(2);
+  if (!contractAddress || !abiPath || !ownerKey || !investorsCsv || !amountsCsv) {
+    console.error('Usage: node admin_buyback.js <contractAddress> <abiPath> <ownerKey> <investorsCsv> <amountsCsv>');
+    process.exit(1);
+  }
+  const abi = JSON.parse(fs.readFileSync(abiPath, 'utf8'));
+  const provider = new ethers.JsonRpcProvider(rpcUrl);
+  const wallet = new ethers.Wallet(ownerKey, provider);
+  const contract = new ethers.Contract(contractAddress, abi, wallet);
+  const investors = investorsCsv.split(',');
+  const amounts = amountsCsv.split(',').map((a) => BigInt(a));
+  const tx = await contract.adminBuyback(investors, amounts);
+  await tx.wait();
+  console.log(JSON.stringify({ txHash: tx.hash }));
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/tests/Feature/AdminBuybackTest.php
+++ b/tests/Feature/AdminBuybackTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Property;
+use App\Models\Investor;
+use App\Models\Investment;
+use App\Models\CarteiraInterna;
+
+class AdminBuybackTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_buyback_updates_wallet_and_records_transaction(): void
+    {
+        $this->withoutMiddleware();
+        $admin = User::factory()->create(['tipo' => 'admin']);
+        $property = Property::factory()->create(['user_id' => $admin->id]);
+        $investor = Investor::factory()->create();
+        CarteiraInterna::factory()->create(['id_investidor' => $investor->id, 'saldo_disponivel' => 0]);
+        Investment::factory()->create([
+            'id_investidor' => $investor->id,
+            'id_imovel' => $property->id,
+            'qtd_tokens' => 10,
+            'valor_unitario' => 2,
+        ]);
+
+        $response = $this->actingAs($admin, 'api')->postJson('/api/admin/imoveis/' . $property->id . '/buyback', [
+            'valor_pago' => 2.5,
+        ]);
+
+        $response->assertStatus(200);
+
+        $this->assertDatabaseHas('carteiras_internas', [
+            'id_investidor' => $investor->id,
+            'saldo_disponivel' => 25,
+        ]);
+
+        $this->assertDatabaseHas('transacoes_financeiras', [
+            'id_investidor' => $investor->id,
+            'tipo' => 'rendimento',
+            'valor' => 25,
+        ]);
+
+        $this->assertDatabaseHas('properties', [
+            'id' => $property->id,
+            'status' => 'vendido',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add Node script to call `adminBuyback` on contract
- create `BuybackController` with API endpoint to process administrative buybacks
- register new `/api/admin/imoveis/{id}/buyback` route
- document API payload in buyback example
- test wallet and property updates after buyback
- revise controller to accept just `valor_pago` and compute payouts automatically
- document how to trigger the endpoint using Postman

## Testing
- `./vendor/bin/phpunit --stop-on-failure` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685f3f327e0c8328a82aaa841a27a8d0